### PR TITLE
replace atoi with strtol

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,15 +150,15 @@ int main(int argc, char **argv)
             i++;
             break;
         case 's':
-            snaplen = atoi(argv[i + 1]);
+            snaplen = strtol(argv[i + 1], NULL, 10);
             i += 2;
             break;
         case 'w':
-            window_interval = atoi(argv[i + 1]);
+            window_interval = strtol(argv[i + 1], NULL, 10);
             i += 2;
             break;
         case 'c':
-            max_unhealthy_count = atoi(argv[i + 1]);
+            max_unhealthy_count = strtol(argv[i + 1], NULL, 10);
             i += 2;
             break;
         case 'D':

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,9 +116,9 @@ int main(int argc, char **argv)
     int rv = EXIT_FAILURE;
     int i;
     char *endptr;
-    long int window_interval = dhcpmon_default_health_check_window;
-    long int max_unhealthy_count = dhcpmon_default_unhealthy_max_count;
-    long int snaplen = dhcpmon_default_snaplen;
+    int window_interval = dhcpmon_default_health_check_window;
+    int max_unhealthy_count = dhcpmon_default_unhealthy_max_count;
+    size_t snaplen = dhcpmon_default_snaplen;
     int make_daemon = 0;
     bool debug_mode = false;
     errno = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include <err.h>
 #include <errno.h>
 #include <libgen.h>
+#include <limits.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>
@@ -152,7 +153,7 @@ int main(int argc, char **argv)
             break;
         case 's':
             snaplen = strtol(argv[i + 1], NULL, 10);
-            if ((errno == ERANGE && (val == LONG_MAX || val == LONG_MIN)) || (errno != 0 && val == 0)) {
+            if ((errno == ERANGE && (snaplen == LONG_MAX || snaplen == LONG_MIN)) || (errno != 0 && snaplen == 0)) {
                 fprintf(stderr, "%s: %s: Invalid snap length\n", basename(argv[0]), argv[i + 1]);
                 usage(basename(argv[0]));
             }
@@ -160,7 +161,7 @@ int main(int argc, char **argv)
             break;
         case 'w':
             window_interval = strtol(argv[i + 1], NULL, 10);
-            if ((errno == ERANGE && (val == LONG_MAX || val == LONG_MIN)) || (errno != 0 && val == 0)) {
+            if ((errno == ERANGE && (window_interval == LONG_MAX || window_interval == LONG_MIN)) || (errno != 0 && window_interval == 0)) {
                 fprintf(stderr, "%s: %s: Invalid window interval\n", basename(argv[0]), argv[i + 1]);
                 usage(basename(argv[0]));
             }
@@ -168,7 +169,7 @@ int main(int argc, char **argv)
             break;
         case 'c':
             max_unhealthy_count = strtol(argv[i + 1], NULL, 10);
-            if ((errno == ERANGE && (val == LONG_MAX || val == LONG_MIN)) || (errno != 0 && val == 0)) {
+            if ((errno == ERANGE && (max_unhealthy_count == LONG_MAX || max_unhealthy_count == LONG_MIN)) || (errno != 0 && max_unhealthy_count == 0)) {
                 fprintf(stderr, "%s: %s: Invalid max unhealthy count\n", basename(argv[0]), argv[i + 1]);
                 usage(basename(argv[0]));
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,9 +115,10 @@ int main(int argc, char **argv)
 {
     int rv = EXIT_FAILURE;
     int i;
-    int window_interval = dhcpmon_default_health_check_window;
-    int max_unhealthy_count = dhcpmon_default_unhealthy_max_count;
-    int snaplen = dhcpmon_default_snaplen;
+    char *endptr;
+    long int window_interval = dhcpmon_default_health_check_window;
+    long int max_unhealthy_count = dhcpmon_default_unhealthy_max_count;
+    long int snaplen = dhcpmon_default_snaplen;
     int make_daemon = 0;
     bool debug_mode = false;
     errno = 0;
@@ -152,24 +153,24 @@ int main(int argc, char **argv)
             i++;
             break;
         case 's':
-            snaplen = strtol(argv[i + 1], NULL, 10);
-            if ((errno == ERANGE && (snaplen == INT_MAX || snaplen == INT_MIN)) || (errno != 0 && snaplen == 0)) {
+            snaplen = strtol(argv[i + 1], &endptr, 10);
+            if (errno != 0 || *endptr != '\0') {
                 fprintf(stderr, "%s: %s: Invalid snap length\n", basename(argv[0]), argv[i + 1]);
                 usage(basename(argv[0]));
             }
             i += 2;
             break;
         case 'w':
-            window_interval = strtol(argv[i + 1], NULL, 10);
-            if ((errno == ERANGE && (window_interval == INT_MAX || window_interval == INT_MIN)) || (errno != 0 && window_interval == 0)) {
+            window_interval = strtol(argv[i + 1], &endptr, 10);
+            if (errno != 0 || *endptr != '\0') {
                 fprintf(stderr, "%s: %s: Invalid window interval\n", basename(argv[0]), argv[i + 1]);
                 usage(basename(argv[0]));
             }
             i += 2;
             break;
         case 'c':
-            max_unhealthy_count = strtol(argv[i + 1], NULL, 10);
-            if ((errno == ERANGE && (max_unhealthy_count == INT_MAX || max_unhealthy_count == INT_MIN)) || (errno != 0 && max_unhealthy_count == 0)) {
+            max_unhealthy_count = strtol(argv[i + 1], &endptr, 10);
+            if (errno != 0 || *endptr != '\0') {
                 fprintf(stderr, "%s: %s: Invalid max unhealthy count\n", basename(argv[0]), argv[i + 1]);
                 usage(basename(argv[0]));
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -119,6 +119,7 @@ int main(int argc, char **argv)
     size_t snaplen = dhcpmon_default_snaplen;
     int make_daemon = 0;
     bool debug_mode = false;
+    int errno = 0;
 
     setlogmask(LOG_UPTO(LOG_INFO));
     openlog(basename(argv[0]), LOG_CONS | LOG_PID | LOG_NDELAY, LOG_DAEMON);
@@ -151,14 +152,26 @@ int main(int argc, char **argv)
             break;
         case 's':
             snaplen = strtol(argv[i + 1], NULL, 10);
+            if ((errno == ERANGE && (val == LONG_MAX || val == LONG_MIN)) || (errno != 0 && val == 0)) {
+                fprintf(stderr, "%s: %s: Invalid snap length\n", basename(argv[0]), argv[i + 1]);
+                usage(basename(argv[0]));
+            }
             i += 2;
             break;
         case 'w':
             window_interval = strtol(argv[i + 1], NULL, 10);
+            if ((errno == ERANGE && (val == LONG_MAX || val == LONG_MIN)) || (errno != 0 && val == 0)) {
+                fprintf(stderr, "%s: %s: Invalid window interval\n", basename(argv[0]), argv[i + 1]);
+                usage(basename(argv[0]));
+            }
             i += 2;
             break;
         case 'c':
             max_unhealthy_count = strtol(argv[i + 1], NULL, 10);
+            if ((errno == ERANGE && (val == LONG_MAX || val == LONG_MIN)) || (errno != 0 && val == 0)) {
+                fprintf(stderr, "%s: %s: Invalid max unhealthy count\n", basename(argv[0]), argv[i + 1]);
+                usage(basename(argv[0]));
+            }
             i += 2;
             break;
         case 'D':

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,7 +117,7 @@ int main(int argc, char **argv)
     int i;
     int window_interval = dhcpmon_default_health_check_window;
     int max_unhealthy_count = dhcpmon_default_unhealthy_max_count;
-    size_t snaplen = dhcpmon_default_snaplen;
+    int snaplen = dhcpmon_default_snaplen;
     int make_daemon = 0;
     bool debug_mode = false;
     errno = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,6 @@
 #include <err.h>
 #include <errno.h>
 #include <libgen.h>
-#include <limits.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
     size_t snaplen = dhcpmon_default_snaplen;
     int make_daemon = 0;
     bool debug_mode = false;
-    int errno = 0;
+    errno = 0;
 
     setlogmask(LOG_UPTO(LOG_INFO));
     openlog(basename(argv[0]), LOG_CONS | LOG_PID | LOG_NDELAY, LOG_DAEMON);
@@ -153,7 +153,7 @@ int main(int argc, char **argv)
             break;
         case 's':
             snaplen = strtol(argv[i + 1], NULL, 10);
-            if ((errno == ERANGE && (snaplen == LONG_MAX || snaplen == LONG_MIN)) || (errno != 0 && snaplen == 0)) {
+            if ((errno == ERANGE && (snaplen == INT_MAX || snaplen == INT_MIN)) || (errno != 0 && snaplen == 0)) {
                 fprintf(stderr, "%s: %s: Invalid snap length\n", basename(argv[0]), argv[i + 1]);
                 usage(basename(argv[0]));
             }
@@ -161,7 +161,7 @@ int main(int argc, char **argv)
             break;
         case 'w':
             window_interval = strtol(argv[i + 1], NULL, 10);
-            if ((errno == ERANGE && (window_interval == LONG_MAX || window_interval == LONG_MIN)) || (errno != 0 && window_interval == 0)) {
+            if ((errno == ERANGE && (window_interval == INT_MAX || window_interval == INT_MIN)) || (errno != 0 && window_interval == 0)) {
                 fprintf(stderr, "%s: %s: Invalid window interval\n", basename(argv[0]), argv[i + 1]);
                 usage(basename(argv[0]));
             }
@@ -169,7 +169,7 @@ int main(int argc, char **argv)
             break;
         case 'c':
             max_unhealthy_count = strtol(argv[i + 1], NULL, 10);
-            if ((errno == ERANGE && (max_unhealthy_count == LONG_MAX || max_unhealthy_count == LONG_MIN)) || (errno != 0 && max_unhealthy_count == 0)) {
+            if ((errno == ERANGE && (max_unhealthy_count == INT_MAX || max_unhealthy_count == INT_MIN)) || (errno != 0 && max_unhealthy_count == 0)) {
                 fprintf(stderr, "%s: %s: Invalid max unhealthy count\n", basename(argv[0]), argv[i + 1]);
                 usage(basename(argv[0]));
             }


### PR DESCRIPTION
From Semgrep: https://semgrep.dev/r?q=c.lang.correctness.incorrect-use-ato-fn.incorrect-use-ato-fn

> Avoid the 'ato*()' family of functions. Their use can lead to undefined behavior, integer overflows, and lack of appropriate error handling. Instead prefer the 'strtol*()' family of functions.

From atoi() man page: https://www.man7.org/linux/man-pages/man3/atoi.3.html

> The atoi() function converts the initial portion of the string pointed to by nptr to int.  The behavior is the same as
>            strtol(nptr, NULL, 10);
> except that atoi() does not detect errors.

Therefore, replace atoi() with strtol()

Verified by kill dhcpmon process, installing new .deb change to dhcp_relay docker, execute dhcpmon process, check if counters is printing in syslog, compare counters before and after this change.
logs: 
[before.txt](https://github.com/sonic-net/sonic-dhcpmon/files/11377335/before.txt)
[after.txt](https://github.com/sonic-net/sonic-dhcpmon/files/11377336/after.txt)

example commands: 
[command.txt](https://github.com/sonic-net/sonic-dhcpmon/files/11423945/command.txt)
