### PR TITLE
Fix libyang package download

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -59,8 +59,8 @@ jobs:
       ${{ else }}:
         artifact: common-lib.${{ parameters.arch }}
       patterns: |
-        target/debs/buster/libyang-*.deb
-        target/debs/buster/libyang_*.deb
+        target/debs/bullseye/libyang-*.deb
+        target/debs/bullseye/libyang_*.deb
     displayName: "Download libyang from common lib"
   - script: |
       set -ex


### PR DESCRIPTION
The buster version of libyang was being used, instead of the bullseye version.