### PR TITLE
dhcp per-interface counter support

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -41,6 +41,7 @@ jobs:
           libnl-route-3-dev \
           libnl-genl-3-dev \
           libnl-nf-3-dev \
+          libjsoncpp-dev \
           libevent-dev
     displayName: "Install dependencies"
   - checkout: self

--- a/objects.mk
+++ b/objects.mk
@@ -1,4 +1,4 @@
 USER_OBJS :=
 
-LIBS := -levent -lexplain -lswsscommon -pthread -lboost_thread -lboost_system -lhiredis
+LIBS := -levent -lexplain -lswsscommon -ljsoncpp -pthread -lboost_thread -lboost_system -lhiredis
 

--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -357,7 +357,10 @@ static void handle_dhcp_option_53(std::string &sock_if,
     std::string context_if(context->intf);
 
     // count for incomming physical interfaces
-    increase_db_counter(sock_if, dhcp_option[2], dir);
+    if (context_if.compare(sock_if) != 0) {
+        increase_db_counter(sock_if, dhcp_option[2], dir);
+        return;
+    }
 
     switch (dhcp_option[2])
     {
@@ -374,9 +377,7 @@ static void handle_dhcp_option_53(std::string &sock_if,
             context->counters[DHCP_COUNTERS_CURRENT][dir][dhcp_option[2]]++;
             aggregate_dev.counters[DHCP_COUNTERS_CURRENT][dir][dhcp_option[2]]++;
             // count for device context interfaces (-d -u -m)
-            if (context_if.compare(sock_if) != 0) {
-                increase_db_counter(context_if, dhcp_option[2], dir);
-            }
+            increase_db_counter(context_if, dhcp_option[2], dir);
         }
         break;
     // DHCP messages send by server
@@ -387,16 +388,14 @@ static void handle_dhcp_option_53(std::string &sock_if,
             (!context->is_uplink && dir == DHCP_TX)) {
             context->counters[DHCP_COUNTERS_CURRENT][dir][dhcp_option[2]]++;
             aggregate_dev.counters[DHCP_COUNTERS_CURRENT][dir][dhcp_option[2]]++;
-            if (context_if.compare(sock_if) != 0) {
-                increase_db_counter(context_if, dhcp_option[2], dir);
-            }
+            // count for device context interfaces (-d -u -m)
+            increase_db_counter(context_if, dhcp_option[2], dir);
         }
         break;
     default:
         syslog(LOG_WARNING, "handle_dhcp_option_53(%s): Unknown DHCP option 53 type %d", context->intf, dhcp_option[2]);
-        if (context_if.compare(sock_if) != 0) {
-            increase_db_counter(context_if, dhcp_option[2], dir);
-        }
+        // count for device context interfaces (-d -u -m)
+        increase_db_counter(context_if, dhcp_option[2], dir);
         break;
     }
 }
@@ -507,9 +506,14 @@ static void read_tx_callback(int fd, short event, void *arg)
             continue;
         }
         std::string intf(interfaceName);
-        context = interface_to_dev_context(devices, intf);
+        context = find_device_context(devices, intf);
         if (context) {
             client_packet_handler(intf, context, tx_recv_buffer, buffer_sz, DHCP_TX);
+        } else {
+            context = interface_to_dev_context(devices, intf);
+            if (context) {
+                client_packet_handler(intf, context, tx_recv_buffer, buffer_sz, DHCP_TX);
+            }
         }
     }
 }
@@ -541,10 +545,15 @@ static void read_rx_callback(int fd, short event, void *arg)
             continue;
         }
         std::string intf(interfaceName);
-        context = interface_to_dev_context(devices, intf);
+        context = find_device_context(devices, intf);
         if (context) {
             client_packet_handler(intf, context, rx_recv_buffer, buffer_sz, DHCP_RX);
-        }
+        } else {
+            context = interface_to_dev_context(devices, intf);
+            if (context) {
+                client_packet_handler(intf, context, rx_recv_buffer, buffer_sz, DHCP_RX);
+            }
+        } 
     }
 }
 

--- a/src/dhcp_device.h
+++ b/src/dhcp_device.h
@@ -194,4 +194,28 @@ void dhcp_device_update_snapshot(dhcp_device_context_t *context);
  */
 void dhcp_device_print_status(dhcp_device_context_t *context, dhcp_counters_type_t type);
 
+/**
+ * @code                void increase_db_counter(std::string &ifname)
+ *
+ * @brief               increase the counter in state_db with interface name
+ *
+ * @param ifname        interface name
+ * 
+ * @return              none
+ */
+void initialize_db_counters(std::string &ifname);
+
+/**
+ * @code                void increase_db_counter(std::string &ifname, uint8_t msg_type, dhcp_packet_direction_t dir)
+ *
+ * @brief               increase the counter in state_db with count of each DHCP message types
+ *
+ * @param ifname        interface name
+ * @param type          dhcp message type to be increased in counter
+ * @param dir           dhcp packet direction
+ * 
+ * @return              none
+ */
+void increase_db_counter(std::string &ifname, uint8_t type, dhcp_packet_direction_t dir);
+
 #endif /* DHCP_DEVICE_H_ */


### PR DESCRIPTION
#### Why I did it
Per-interface counter support for dhcp packets in dhcpmon.
 
##### Work item tracking
- Microsoft ADO **(17271822)**:

#### How I did it
Add "DHCP_COUNTER_TABLE|<interface name>" in Redis STATE_DB. 

#### How to verify it
Maunally test and run test_dhcp_relay.py

#### Test log
```
1)	Discover from Ethernet4, with 48 servers
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet4'
{'RX': '{"Ack":"0","Decline":"0","Discover":"1","Inform":"0","Nak":"0","Offer":"0","Release":"0","Request":"0","Unknown":"0"}', 'TX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}"}

admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Vlan1000'
{'RX': '{"Ack":"0","Decline":"0","Discover":"1","Inform":"0","Nak":"0","Offer":"0","Release":"0","Request":"0","Unknown":"0"}', 'TX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}"}

admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|PortChannel101'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"14","Inform":"0","Nak":"0","Offer":"0","Release":"0","Request":"0","Unknown":"0"}'}

admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|PortChannel102'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"11","Inform":"0","Nak":"0","Offer":"0","Release":"0","Request":"0","Unknown":"0"}'}

admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|PortChannel103'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"10","Inform":"0","Nak":"0","Offer":"0","Release":"0","Request":"0","Unknown":"0"}'}

admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|PortChannel104'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"13","Inform":"0","Nak":"0","Offer":"0","Release":"0","Request":"0","Unknown":"0"}'}

admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet112'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"14","Inform":"0","Nak":"0","Offer":"0","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet116'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"11","Inform":"0","Nak":"0","Offer":"0","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet120'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"10","Inform":"0","Nak":"0","Offer":"0","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet124'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"13","Inform":"0","Nak":"0","Offer":"0","Release":"0","Request":"0","Unknown":"0"}'}

2)	Offer from Ethernet112 PortChannel101, and broadcast to Vlan1000 member interfaces
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet112'
{'RX': '{"Ack":"0","Decline":"0","Discover":"0","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}', 'TX': '{"Ack":"0","Decline":"0","Discover":"14","Inform":"0","Nak":"0","Offer":"0","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|PortChannel101'
{'RX': '{"Ack":"0","Decline":"0","Discover":"0","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}', 'TX': '{"Ack":"0","Decline":"0","Discover":"14","Inform":"0","Nak":"0","Offer":"0","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Vlan1000'
{'RX': '{"Ack":"0","Decline":"0","Discover":"1","Inform":"0","Nak":"0","Offer":"0","Release":"0","Request":"0","Unknown":"0"}', 'TX': '{"Ack":"0","Decline":"0","Discover":"0","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}

admin@str2-7050cx3-acs-02:~$ show vlan bri
+-----------+-----------------+------------+----------------+-------------+-----------------------+
|   VLAN ID | IP Address      | Ports      | Port Tagging   | Proxy ARP   | DHCP Helper Address   |
+===========+=================+============+================+=============+=======================+
|      1000 | 192.168.0.1/21  | Ethernet4  | untagged       | disabled    | 192.0.0.1             |
|           | fc02:1000::1/64 | Ethernet8  | untagged       |             | 192.0.0.2             |
|           |                 | Ethernet12 | untagged       |             | 192.0.0.3             |
|           |                 | Ethernet16 | untagged       |             | 192.0.0.4             |
|           |                 | Ethernet20 | untagged       |             | 192.0.0.5             |
|           |                 | Ethernet24 | untagged       |             | 192.0.0.6             |
|           |                 | Ethernet28 | untagged       |             | 192.0.0.7             |
|           |                 | Ethernet32 | untagged       |             | 192.0.0.8             |
|           |                 | Ethernet36 | untagged       |             | 192.0.0.9             |
|           |                 | Ethernet40 | untagged       |             | 192.0.0.10            |
|           |                 | Ethernet44 | untagged       |             | 192.0.0.11            |
|           |                 | Ethernet48 | untagged       |             | 192.0.0.12            |
|           |                 | Ethernet52 | untagged       |             | 192.0.0.13            |
|           |                 | Ethernet56 | untagged       |             | 192.0.0.14            |
|           |                 | Ethernet60 | untagged       |             | 192.0.0.15            |
|           |                 | Ethernet64 | untagged       |             | 192.0.0.16            |
|           |                 | Ethernet68 | untagged       |             | 192.0.0.17            |
|           |                 | Ethernet72 | untagged       |             | 192.0.0.18            |
|           |                 | Ethernet76 | untagged       |             | 192.0.0.19            |
|           |                 | Ethernet80 | untagged       |             | 192.0.0.20            |
|           |                 | Ethernet84 | untagged       |             | 192.0.0.21            |
|           |                 | Ethernet88 | untagged       |             | 192.0.0.22            |
|           |                 | Ethernet92 | untagged       |             | 192.0.0.23            |
|           |                 | Ethernet96 | untagged       |             | 192.0.0.24            |
|           |                 |            |                |             | 192.0.0.25            |
|           |                 |            |                |             | 192.0.0.26            |
|           |                 |            |                |             | 192.0.0.27            |
|           |                 |            |                |             | 192.0.0.28            |
|           |                 |            |                |             | 192.0.0.29            |
|           |                 |            |                |             | 192.0.0.30            |
|           |                 |            |                |             | 192.0.0.31            |
|           |                 |            |                |             | 192.0.0.32            |
|           |                 |            |                |             | 192.0.0.33            |
|           |                 |            |                |             | 192.0.0.34            |
|           |                 |            |                |             | 192.0.0.35            |
|           |                 |            |                |             | 192.0.0.36            |
|           |                 |            |                |             | 192.0.0.37            |
|           |                 |            |                |             | 192.0.0.38            |
|           |                 |            |                |             | 192.0.0.39            |
|           |                 |            |                |             | 192.0.0.40            |
|           |                 |            |                |             | 192.0.0.41            |
|           |                 |            |                |             | 192.0.0.42            |
|           |                 |            |                |             | 192.0.0.43            |
|           |                 |            |                |             | 192.0.0.44            |
|           |                 |            |                |             | 192.0.0.45            |
|           |                 |            |                |             | 192.0.0.46            |
|           |                 |            |                |             | 192.0.0.47            |
|           |                 |            |                |             | 192.0.0.48            |
+-----------+-----------------+------------+----------------+-------------+-----------------------+
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet4'
{'RX': '{"Ack":"0","Decline":"0","Discover":"1","Inform":"0","Nak":"0","Offer":"0","Release":"0","Request":"0","Unknown":"0"}', 'TX': '{"Ack":"0","Decline":"0","Discover":"0","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet8'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"1","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet12'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"0","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet16'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"0","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet20'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"0","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet24'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"0","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet28'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"0","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet32'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"0","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet36'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"0","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet40'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"0","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet44'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"0","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet48'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"0","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet52'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"1","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet56'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"1","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet60'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"1","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet64'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"1","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet68'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"1","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet72'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"1","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet76'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"1","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet80'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"1","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet84'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"1","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet88'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"1","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet92'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"1","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}
admin@str2-7050cx3-acs-02:~$ sonic-db-cli STATE_DB hgetall 'DHCP_COUNTER_TABLE|Ethernet96'
{'RX': "{'Unknown':'0','Discover':'0','Offer':'0','Request':'0','Decline':'0','Ack':'0','Nak':'0','Release':'0','Inform':'0'}", 'TX': '{"Ack":"0","Decline":"0","Discover":"1","Inform":"0","Nak":"0","Offer":"1","Release":"0","Request":"0","Unknown":"0"}'}

```


