### PR TITLE
[counter] Clear counter table when dhcpmon init

### DIFF
--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -194,6 +194,25 @@ void update_vlan_mapping(std::shared_ptr<swss::DBConnector> db_conn) {
     }
 }
 
+
+/**
+ * @code clear_counter(std::shared_ptr<swss::DBConnector> state_db);
+ *
+ * @brief Clear all counter
+ *
+ * @param state_db      state_db connector pointer
+ *
+ */
+void clear_counter(std::shared_ptr<swss::DBConnector> state_db) {
+    std::string match_pattern = DB_COUNTER_TABLE + std::string("*");
+    auto keys = state_db->keys(match_pattern);
+
+    for (auto &itr : keys) {
+        state_db->del(itr);
+    }
+}
+
+
 /** update ethernet interface to port-channel map
  *  PORTCHANNEL_MEMBER|PortChannel101|Ethernet112
  */
@@ -265,7 +284,6 @@ void initialize_db_counters(std::string &ifname)
 {
     auto table_name = DB_COUNTER_TABLE + ifname;
     auto init_value = gen_counter_json_str(db_counter);
-    mStateDbPtr->del(table_name);
     mStateDbPtr->hset(table_name, "RX", init_value);
     mStateDbPtr->hset(table_name, "TX", init_value);
 }
@@ -924,6 +942,7 @@ int dhcp_device_start_capture(size_t snaplen, struct event_base *base, in_addr_t
 
         init_recv_buffers(snaplen);
 
+        clear_counter(mStateDbPtr);
         update_vlan_mapping(mConfigDbPtr);
         update_portchannel_mapping(mConfigDbPtr);
         update_mgmt_mapping();


### PR DESCRIPTION
#### Why I did it
Fix issue https://github.com/sonic-net/sonic-buildimage/issues/15047
dhcp counter didn't restore after config reload

##### Work item tracking
- Microsoft ADO **(number only)**: 26270786

#### How I did it
1. Clear all counters when dhcpmon start
2. Remove clear counter in `initialize_counter` since they are cleared in previous

#### How to verify it
1. Build debian packet and install in DUT do manually testing
2. Run dhcp_relay test, all passed
```
collected 22 items                                                                                                                                                                           

dhcp_relay/test_dhcp_pkt_fwd.py::TestDhcpPktFwd::testDhcpPacketForwarding[pktInfo0] PASSED                                                                                             [  4%]
dhcp_relay/test_dhcp_pkt_fwd.py::TestDhcpPktFwd::testDhcpPacketForwarding[pktInfo1] PASSED                                                                                             [  9%]
dhcp_relay/test_dhcp_pkt_fwd.py::TestDhcpPktFwd::testDhcpPacketForwarding[pktInfo2] PASSED                                                                                             [ 13%]
dhcp_relay/test_dhcp_pkt_fwd.py::TestDhcpPktFwd::testDhcpPacketForwarding[pktInfo3] PASSED                                                                                             [ 18%]
dhcp_relay/test_dhcp_relay.py::test_interface_binding PASSED                                                                                                                           [ 22%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default[single] PASSED                                                                                                                  [ 27%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_after_link_flap[single] PASSED                                                                                                          [ 31%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_start_with_uplinks_down[single] PASSED                                                                                                  [ 36%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac[single] PASSED                                                                                                              [ 40%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_random_sport[single] PASSED                                                                                                             [ 45%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_counter[single] PASSED                                                                                                                  [ 50%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default[dual] SKIPPED (skip DUAL_TOR_MODE tests on Single ToR testbeds)                                                                 [ 54%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_after_link_flap[dual] SKIPPED (skip DUAL_TOR_MODE tests on Single ToR testbeds)                                                         [ 59%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_start_with_uplinks_down[dual] SKIPPED (skip DUAL_TOR_MODE tests on Single ToR testbeds)                                                 [ 63%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac[dual] SKIPPED (skip DUAL_TOR_MODE tests on Single ToR testbeds)                                                             [ 68%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_random_sport[dual] SKIPPED (skip DUAL_TOR_MODE tests on Single ToR testbeds)                                                            [ 72%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_counter[dual] SKIPPED (skip DUAL_TOR_MODE tests on Single ToR testbeds)                                                                 [ 77%]
dhcp_relay/test_dhcpv6_relay.py::test_interface_binding PASSED                                                                                                                         [ 81%]
dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter PASSED                                                                                                                      [ 86%]
dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_default PASSED                                                                                                                        [ 90%]
dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_after_link_flap PASSED                                                                                                                [ 95%]
dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_start_with_uplinks_down PASSED                                                                                                        [100%]
```