### PR TITLE
Fix DHCP Counter revert diff

### DIFF
--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -364,7 +364,7 @@ static void read_tx_callback(int fd, short event, void *arg)
             continue;
         }
         std::string intf(interfaceName);
-        context = interface_to_dev_context(devices, intf);
+        context = find_device_context(devices, intf);
         if (context) {
             client_packet_handler(context, tx_recv_buffer, buffer_sz, DHCP_TX);
         }


### PR DESCRIPTION
```
kellyyeh@kellyyeh-vm:~/sonic-dhcpmon$ git diff b1d890a59cb3d4ca2a85adb07607352e4276a7f2 a3c5381307ec4f7fbcc2ac8626caf3b32d997127
diff --git a/src/dhcp_device.cpp b/src/dhcp_device.cpp
index 4db1f88..ac46ef6 100644
--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -364,7 +364,7 @@ static void read_tx_callback(int fd, short event, void *arg)
             continue;
         }
         std::string intf(interfaceName);
-        context = interface_to_dev_context(devices, intf);
+        context = find_device_context(devices, intf);
         if (context) {
             client_packet_handler(context, tx_recv_buffer, buffer_sz, DHCP_TX);
         }
```