### PR TITLE
Fix server side RX counter didn't count packet on north interface

### DIFF
--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -372,8 +372,6 @@ static void read_tx_callback(int fd, short event, void *arg)
         context = find_device_context(devices, intf);
         if (context) {
             client_packet_handler(context, tx_recv_buffer, buffer_sz, DHCP_TX);
-        } else {
-            syslog(LOG_WARNING, "context not found for interface %s\n", interfaceName);
         }
     }
 }
@@ -406,10 +404,11 @@ static void read_rx_callback(int fd, short event, void *arg)
         }
         std::string intf(interfaceName);
         context = interface_to_dev_context(devices, intf);
+        if (!context) {
+            context = find_device_context(devices, intf);
+        }
         if (context) {
             client_packet_handler(context, rx_recv_buffer, buffer_sz, DHCP_RX);
-        } else {
-            syslog(LOG_WARNING, "context not found for interface %s\n", interfaceName);
         }
     }
 }

--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -372,6 +372,8 @@ static void read_tx_callback(int fd, short event, void *arg)
         context = find_device_context(devices, intf);
         if (context) {
             client_packet_handler(context, tx_recv_buffer, buffer_sz, DHCP_TX);
+        } else {
+            syslog(LOG_WARNING, "context not found for interface %s\n", interfaceName);
         }
     }
 }
@@ -406,6 +408,8 @@ static void read_rx_callback(int fd, short event, void *arg)
         context = interface_to_dev_context(devices, intf);
         if (context) {
             client_packet_handler(context, rx_recv_buffer, buffer_sz, DHCP_RX);
+        } else {
+            syslog(LOG_WARNING, "context not found for interface %s\n", interfaceName);
         }
     }
 }

--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -780,25 +780,14 @@ int dhcp_device_start_capture(size_t snaplen, struct event_base *base, in_addr_t
             exit(1);
         }
 
-        // in init_socket it done below:
-        // for (auto &itr : intfs) {
-        //     itr.second->dev_context->rx_sock = rx_sock;
-        //     itr.second->dev_context->tx_sock = tx_sock;
-        // }
         init_socket();
 
         init_recv_buffers(snaplen);
 
-        // Done in update_vlan_mapping
-        // vlan_map[interface] = vlan;
         update_vlan_mapping(mConfigDbPtr);
 
-        // Done in update_portchannel_mapping
-        // portchan_map[interface] = portchannel;
         update_portchannel_mapping(mConfigDbPtr);
 
-        // Done in update_mgmt_mapping
-        // mgmt_map[name] = name;
         update_mgmt_mapping();
 
         for (auto &itr : intfs) {

--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -589,14 +589,6 @@ static int init_socket()
     int rv = -1;
 
     do {
-        // https://www.man7.org/linux/man-pages/man2/socket.2.html
-        // AF_PACKET means: Low-level packet interface 
-        // SOCK_NONBLOCK
-            //   Set the O_NONBLOCK file status flag on the open file
-            //   description (see open(2)) referred to by the new file
-            //   descriptor.  Using this flag saves extra calls to fcntl(2)
-            //   to achieve the same result.
-        // When protocol is set to htons(ETH_P_ALL), then all protocols are received.
         auto rx_sock = socket(AF_PACKET, SOCK_RAW | SOCK_NONBLOCK, htons(ETH_P_ALL));
         auto tx_sock = socket(AF_PACKET, SOCK_RAW | SOCK_NONBLOCK, htons(ETH_P_ALL));
         if (rx_sock < 0 || tx_sock < 0) {

--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -288,6 +288,7 @@ static void client_packet_handler(dhcp_device_context_t *context, uint8_t *buffe
     if (((unsigned)buffer_sz > UDP_START_OFFSET + sizeof(struct udphdr) + DHCP_OPTIONS_HEADER_SIZE) &&
         (ntohs(udp->len) > DHCP_OPTIONS_HEADER_SIZE))
     {
+        syslog(LOG_ALERT, "Got dhcp packet with direction %s on intf %s\n", dir == DHCP_RX ? "RX" : "TX", context->intf);
         int dhcp_sz = ntohs(udp->len) < buffer_sz - UDP_START_OFFSET - sizeof(struct udphdr) ?
                     ntohs(udp->len) : buffer_sz - UDP_START_OFFSET - sizeof(struct udphdr);
         int dhcp_option_sz = dhcp_sz - DHCP_OPTIONS_HEADER_SIZE;

--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -179,7 +179,7 @@ void update_vlan_mapping_and_set(std::shared_ptr<swss::DBConnector> db_conn) {
         syslog(LOG_INFO, "add <%s, %s> into interface vlan map\n", interface.c_str(), vlan.c_str());
         auto ret = vlan_set.insert(vlan);
         if (ret.second) {
-            syslog(LOG_ERR, "add vlan %s into vlan set\n", vlan.c_str());
+            syslog(LOG_INFO, "add vlan %s into vlan set\n", vlan.c_str());
         }
     }
 }
@@ -199,7 +199,7 @@ void update_portchannel_mapping_and_set(std::shared_ptr<swss::DBConnector> db_co
         syslog(LOG_INFO, "add <%s, %s> into interface port-channel map\n", interface.c_str(), portchannel.c_str());
         auto ret = portchan_set.insert(portchannel);
         if (ret.second) {
-            syslog(LOG_ERR, "add port-channel %s into port-channel set\n", portchannel.c_str());
+            syslog(LOG_INFO, "add port-channel %s into port-channel set\n", portchannel.c_str());
         }
     }
 }
@@ -344,7 +344,7 @@ static dhcp_device_context_t *interface_to_dev_context(std::unordered_map<std::s
             auto mgmt = mgmt_map.find(ifname);
             if (mgmt != mgmt_map.end()) {
                 return find_device_context(devices, mgmt->second);
-            } else if (vlan_set.find(ifname) == vlan_set.end() ||
+            } else if (vlan_set.find(ifname) == vlan_set.end() &&
                        portchan_set.find(ifname) == portchan_set.end()) {
                 return find_device_context(devices, ifname);
             }

--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -239,7 +239,7 @@ static void handle_dhcp_option_53(dhcp_device_context_t *context,
     case DHCP_MESSAGE_TYPE_DECLINE:
     case DHCP_MESSAGE_TYPE_RELEASE:
     case DHCP_MESSAGE_TYPE_INFORM:
-        syslog(LOG_ALERT, "Got client packet with direction %s on intf %s\n", dir, context->intf);
+        syslog(LOG_ALERT, "Got client packet with direction %s on intf %s\n", dir == DHCP_RX ? "RX" : "TX", context->intf);
         giaddr = ntohl(dhcphdr[DHCP_GIADDR_OFFSET] << 24 | dhcphdr[DHCP_GIADDR_OFFSET + 1] << 16 |
                        dhcphdr[DHCP_GIADDR_OFFSET + 2] << 8 | dhcphdr[DHCP_GIADDR_OFFSET + 3]);
         if ((context->giaddr_ip == giaddr && context->is_uplink && dir == DHCP_TX) ||
@@ -253,7 +253,7 @@ static void handle_dhcp_option_53(dhcp_device_context_t *context,
     case DHCP_MESSAGE_TYPE_OFFER:
     case DHCP_MESSAGE_TYPE_ACK:
     case DHCP_MESSAGE_TYPE_NAK:
-        syslog(LOG_ALERT, "Got server packet with direction %son intf %s\n", dir, context->intf);
+        syslog(LOG_ALERT, "Got server packet with direction %s on intf %s\n", dir == DHCP_RX ? "RX" : "TX", context->intf);
         if ((context->giaddr_ip == iphdr->ip_dst.s_addr && context->is_uplink && dir == DHCP_RX) ||
             (!context->is_uplink && dir == DHCP_TX)) {
             context->counters[DHCP_COUNTERS_CURRENT][dir][dhcp_option[2]]++;


### PR DESCRIPTION
# Why I raise this PR:

When the north interface is neither belonging to any VLAN nor any portchannel, the server side RX counter won't count any packet.



# How I fix this:

use the different method to get interface device context.



# Before change:

Jul 12 06:09:41.937089 bjw2-can-7215-2 NOTICE dhcp_relay#dhcpmon[136]: [            eth0- Current rx/tx] Discover:         0/        0, Offer:         0/        0, Request:         0/        0, ACK:         0/        0
Jul 12 06:09:41.937089 bjw2-can-7215-2 NOTICE dhcp_relay#dhcpmon[136]: [         docker0- Current rx/tx] Discover:         0/        1, Offer:         0/        0, Request:         0/        1, ACK:         0/        0
Jul 12 06:09:41.937089 bjw2-can-7215-2 NOTICE dhcp_relay#dhcpmon[136]: [        Vlan1000- Current rx/tx] Discover:         1/        0, Offer:         0/        1, Request:         1/        0, ACK:         0/        1
Jul 12 06:09:41.937089 bjw2-can-7215-2 NOTICE dhcp_relay#dhcpmon[136]: [    Agg-Vlan1000- Current rx/tx] Discover:         1/        1, **Offer:         0/        1**, Request:         1/        1, **ACK:         0/        1**


# After change:

Jul 15 13:59:58.417008 bjw2-can-7215-2 NOTICE dhcp_relay#dhcpmon[177]: [            eth0- Current rx/tx] Discover:         0/        0, Offer:         0/        0, Request:         0/        0, ACK:         0/        0
Jul 15 13:59:58.417248 bjw2-can-7215-2 NOTICE dhcp_relay#dhcpmon[177]: [         docker0- Current rx/tx] Discover:         0/        1, Offer:         1/        0, Request:         0/        1, ACK:         1/        0
Jul 15 13:59:58.417484 bjw2-can-7215-2 NOTICE dhcp_relay#dhcpmon[177]: [         Vlan1000- Current rx/tx] Discover:         1/        0, Offer:         0/        1, Request:         1/        0, ACK:         0/        1
Jul 15 13:59:58.417731 bjw2-can-7215-2 NOTICE dhcp_relay#dhcpmon[177]: [     Agg-Vlan1000- Current rx/tx] Discover:         1/        1, **Offer:         1/        1**, Request:         1/        1, **ACK:         1/        1**
