### PR TITLE
[Build] Update to buijld bookworm debian package

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -59,8 +59,8 @@ jobs:
       ${{ else }}:
         artifact: common-lib.${{ parameters.arch }}
       patterns: |
-        target/debs/bullseye/libyang-*.deb
-        target/debs/bullseye/libyang_*.deb
+        target/debs/bookworm/libyang-*.deb
+        target/debs/bookworm/libyang_*.deb
     displayName: "Download libyang from common lib"
   - script: |
       set -ex
@@ -73,9 +73,9 @@ jobs:
       project: build
       pipeline: Azure.sonic-swss-common
       ${{ if eq(parameters.arch, 'amd64') }}:
-        artifact: sonic-swss-common
+        artifact: sonic-swss-common-bookworm
       ${{ else }}:
-        artifact: sonic-swss-common.${{ parameters.arch }}
+        artifact: sonic-swss-common-bookworm.${{ parameters.arch }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/master'
       displayName: "Download sonic-swss-common"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,14 +15,14 @@ jobs:
     pool:
       vmImage: 'ubuntu-20.04'
     codeCoverage: false
-    containerImage: sonicdev-microsoft.azurecr.io:443/sonic-slave-bullseye:latest
+    containerImage: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:latest
 - template: .azure-pipelines/build.yml
   parameters:
     arch: arm64
     pool: sonicbld-arm64
-    containerImage: sonicdev-microsoft.azurecr.io:443/sonic-slave-bullseye-arm64:latest
+    containerImage: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm-arm64:latest
 - template: .azure-pipelines/build.yml
   parameters:
     arch: armhf
     pool: sonicbld-armhf
-    containerImage: sonicdev-microsoft.azurecr.io:443/sonic-slave-bullseye-armhf:latest
+    containerImage: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm-armhf:latest


### PR DESCRIPTION
Master build for swss-common has been updated to from bullseye to bookworm https://github.com/sonic-net/sonic-swss-common/pull/937/files, hence updated correspond build in current PR