### PR TITLE
Fix counting bootp packets by mistake

### DIFF
--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -43,7 +43,11 @@
 #define DHCP_OPTIONS_HEADER_SIZE 240
 /** Offset of DHCP GIADDR */
 #define DHCP_GIADDR_OFFSET 24
+/** Offset of magic cookie */
+#define MAGIC_COOKIE_OFFSET 236
 #define CLIENT_IF_PREFIX "Ethernet"
+/** 32-bit decimal of 99.130.83.99 (indicate DHCP packets), Refer to RFC 2131 */
+#define DHCP_MAGIC_COOKIE 1669485411
 
 #define OP_LDHA     (BPF_LD  | BPF_H   | BPF_ABS)   /** bpf ldh Abs */
 #define OP_LDHI     (BPF_LD  | BPF_H   | BPF_IND)   /** bpf ldh Ind */
@@ -288,7 +292,14 @@ static void client_packet_handler(dhcp_device_context_t *context, uint8_t *buffe
                     ntohs(udp->len) : buffer_sz - UDP_START_OFFSET - sizeof(struct udphdr);
         int dhcp_option_sz = dhcp_sz - DHCP_OPTIONS_HEADER_SIZE;
         const u_char *dhcp_option = buffer + dhcp_option_offset;
-        
+        uint32_t magic_cookie = dhcphdr[MAGIC_COOKIE_OFFSET] << 24 | dhcphdr[MAGIC_COOKIE_OFFSET + 1] << 16 |
+                                dhcphdr[MAGIC_COOKIE_OFFSET + 2] << 8 | dhcphdr[MAGIC_COOKIE_OFFSET + 3];
+        // If magic cookie not equals to DHCP value, its format is not DHCP format, shouldn't count as DHCP packets.
+        if (magic_cookie != DHCP_MAGIC_COOKIE) {
+            context->counters[DHCP_COUNTERS_CURRENT][dir][BOOTP_MESSAGE]++;
+            aggregate_dev.counters[DHCP_COUNTERS_CURRENT][dir][BOOTP_MESSAGE]++;
+            return;
+        }
         int offset = 0;
         while ((offset < (dhcp_option_sz + 1)) && dhcp_option[offset] != 255) {
             if (dhcp_option[offset] == OPTION_DHCP_MESSAGE_TYPE) {

--- a/src/dhcp_device.h
+++ b/src/dhcp_device.h
@@ -32,6 +32,7 @@ typedef enum
     DHCP_MESSAGE_TYPE_NAK      = 6,
     DHCP_MESSAGE_TYPE_RELEASE  = 7,
     DHCP_MESSAGE_TYPE_INFORM   = 8,
+    BOOTP_MESSAGE              = 9,
 
     DHCP_MESSAGE_TYPE_COUNT
 } dhcp_message_type_t;


### PR DESCRIPTION
### Why I did it
In previous, if switch receives bootp packets with vendor specific options rather than DHCP body, dhcpmon would treat them as DHCP packets and count them. Since the packets body is not DHCP format, it's not expected and would cause incorrect counting data generated
![image](https://github.com/user-attachments/assets/533d7649-6efe-462b-a356-de619a2e1510)

### How I did it
Per RFC 2131, add check for DHCP magic cookie to make sure dhcpmon would only count DHCP packets
```
The first four octets of the 'options' field of the DHCP message
   contain the (decimal) values 99, 130, 83 and 99, respectively (this
   is the same magic cookie as is defined in [RFC 1497](https://www.rfc-editor.org/rfc/rfc1497) [[17](https://www.rfc-editor.org/rfc/rfc2131#ref-17)]).  The
   remainder of the 'options' field consists of a list of tagged
   parameters that are called "options".  All of the "vendor extensions"
   listed in [RFC 1497](https://www.rfc-editor.org/rfc/rfc1497) are also DHCP options.  [RFC 1533](https://www.rfc-editor.org/rfc/rfc1533) gives the
   complete set of options defined for use with DHCP.
```

### How I verify it
1. Install new dhcpmon and send bootp packets manully and we can see bootp packets wouldn't be counted as DHCP packets
2. Install new dhcpmon and run dhcp_relay related tests in sonic-mgmt, all passed
```
collected 25 items                                                                                                        

dhcp_relay/test_dhcp_pkt_fwd.py::TestDhcpPktFwd::testDhcpPacketForwarding[pktInfo0] PASSED                          [  4%]
dhcp_relay/test_dhcp_pkt_fwd.py::TestDhcpPktFwd::testDhcpPacketForwarding[pktInfo1] PASSED                          [  8%]
dhcp_relay/test_dhcp_pkt_fwd.py::TestDhcpPktFwd::testDhcpPacketForwarding[pktInfo2] PASSED                          [ 12%]
dhcp_relay/test_dhcp_pkt_fwd.py::TestDhcpPktFwd::testDhcpPacketForwarding[pktInfo3] PASSED                          [ 16%]
dhcp_relay/test_dhcp_pkt_recv.py::TestDhcpv6WithEmptyAclTable::test_dhcpv6_multicast_recv PASSED                    [ 20%]
dhcp_relay/test_dhcp_pkt_recv.py::TestDhcpv6WithMulticastAccpectAcl::test_dhcpv6_multicast_recv PASSED              [ 24%]
dhcp_relay/test_dhcp_relay.py::test_interface_binding PASSED                                                        [ 28%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_default 
------------------------------------------------------ live log call ------------------------------------------------------
02:40:51 ptf_runner.get_dut_type                  L0051 WARNING| DUT type file doesn't exist.
PASSED                                                                                                              [ 32%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_with_source_port_ip_in_relay_enabled 
------------------------------------------------------ live log call ------------------------------------------------------
02:43:22 ptf_runner.get_dut_type                  L0051 WARNING| DUT type file doesn't exist.
PASSED                                                                                                              [ 36%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_after_link_flap 
------------------------------------------------------ live log call ------------------------------------------------------
02:46:30 ptf_runner.get_dut_type                  L0051 WARNING| DUT type file doesn't exist.
PASSED                                                                                                              [ 40%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_start_with_uplinks_down 
------------------------------------------------------ live log call ------------------------------------------------------
02:48:29 ptf_runner.get_dut_type                  L0051 WARNING| DUT type file doesn't exist.
PASSED                                                                                                              [ 44%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_unicast_mac 
------------------------------------------------------ live log call ------------------------------------------------------
02:49:02 ptf_runner.get_dut_type                  L0051 WARNING| DUT type file doesn't exist.
PASSED                                                                                                              [ 48%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_random_sport 
------------------------------------------------------ live log call ------------------------------------------------------
02:49:29 ptf_runner.get_dut_type                  L0051 WARNING| DUT type file doesn't exist.
PASSED                                                                                                              [ 52%]
dhcp_relay/test_dhcp_relay.py::test_dhcp_relay_counter SKIPPED (skip the dhcpv4 counter testing)                    [ 56%]
dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_restart_with_stress 
------------------------------------------------------ live log call ------------------------------------------------------
02:54:05 ptf_runner.get_dut_type                  L0051 WARNING| DUT type file doesn't exist.
PASSED                                                                                                              [ 60%]
dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress[discover] SKIPPED (Testcase ignored due to github ...) [ 64%]
dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress[offer] 
------------------------------------------------------ live log call ------------------------------------------------------
03:04:26 ptf_runner.get_dut_type                  L0051 WARNING| DUT type file doesn't exist.
PASSED                                                                                                              [ 68%]
dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress[request] SKIPPED (Testcase ignored due to github i...) [ 72%]
dhcp_relay/test_dhcp_relay_stress.py::test_dhcp_relay_stress[ack] 
------------------------------------------------------ live log call ------------------------------------------------------
03:08:03 ptf_runner.get_dut_type                  L0051 WARNING| DUT type file doesn't exist.
PASSED                                                                                                              [ 76%]
dhcp_relay/test_dhcpv6_relay.py::test_interface_binding PASSED                                                      [ 80%]
dhcp_relay/test_dhcpv6_relay.py::test_dhcpv6_relay_counter 
------------------------------------------------------ live log call ------------------------------------------------------
03:19:19 ptf_runner.get_dut_type                  L0051 WARNING| DUT type file doesn't exist.
PASSED                                                                                                              [ 84%]
dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_default 
------------------------------------------------------ live log call ------------------------------------------------------
03:20:46 ptf_runner.get_dut_type                  L0051 WARNING| DUT type file doesn't exist.
PASSED                                                                                                              [ 88%]
dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_after_link_flap 
------------------------------------------------------ live log call ------------------------------------------------------
03:21:55 ptf_runner.get_dut_type                  L0051 WARNING| DUT type file doesn't exist.
PASSED                                                                                                              [ 92%]
dhcp_relay/test_dhcpv6_relay.py::test_dhcp_relay_start_with_uplinks_down 
------------------------------------------------------ live log call ------------------------------------------------------
03:23:57 ptf_runner.get_dut_type                  L0051 WARNING| DUT type file doesn't exist.
PASSED                                                                                                              [ 96%]
dhcp_relay/test_dhcpv6_relay.py::TestDhcpv6RelayWithMultipleVlan::test_dhcp_relay_default[3]      
------------------------------------------------------ live log call ------------------------------------------------------
03:28:22 ptf_runner.get_dut_type                  L0051 WARNING| DUT type file doesn't exist.
03:28:38 ptf_runner.get_dut_type                  L0051 WARNING| DUT type file doesn't exist.
03:28:55 ptf_runner.get_dut_type                  L0051 WARNING| DUT type file doesn't exist.
PASSED                                                                                                              [100%]

==================================================== warnings summary =====================================================
================================================= short test summary info =================================================
SKIPPED [1] dhcp_relay/test_dhcp_relay.py:571: skip the dhcpv4 counter testing
SKIPPED [2] dhcp_relay/test_dhcp_relay_stress.py:133: Testcase ignored due to github issue: https://github.com/sonic-net/sonic-mgmt/issues/14851
================================= 22 passed, 3 skipped, 9 warnings in 3971.20s (1:06:11) ==================================
```
