### PR TITLE
[202311 ]Fix counting bootp packets by mistake (#31)

### DIFF
--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -43,7 +43,11 @@
 #define DHCP_OPTIONS_HEADER_SIZE 240
 /** Offset of DHCP GIADDR */
 #define DHCP_GIADDR_OFFSET 24
+/** Offset of magic cookie */
+#define MAGIC_COOKIE_OFFSET 236
 #define CLIENT_IF_PREFIX "Ethernet"
+/** 32-bit decimal of 99.130.83.99 (indicate DHCP packets), Refer to RFC 2131 */
+#define DHCP_MAGIC_COOKIE 1669485411
 
 #define OP_LDHA     (BPF_LD  | BPF_H   | BPF_ABS)   /** bpf ldh Abs */
 #define OP_LDHI     (BPF_LD  | BPF_H   | BPF_IND)   /** bpf ldh Ind */
@@ -288,7 +292,14 @@ static void client_packet_handler(dhcp_device_context_t *context, uint8_t *buffe
                     ntohs(udp->len) : buffer_sz - UDP_START_OFFSET - sizeof(struct udphdr);
         int dhcp_option_sz = dhcp_sz - DHCP_OPTIONS_HEADER_SIZE;
         const u_char *dhcp_option = buffer + dhcp_option_offset;
-        
+        uint32_t magic_cookie = dhcphdr[MAGIC_COOKIE_OFFSET] << 24 | dhcphdr[MAGIC_COOKIE_OFFSET + 1] << 16 |
+                                dhcphdr[MAGIC_COOKIE_OFFSET + 2] << 8 | dhcphdr[MAGIC_COOKIE_OFFSET + 3];
+        // If magic cookie not equals to DHCP value, its format is not DHCP format, shouldn't count as DHCP packets.
+        if (magic_cookie != DHCP_MAGIC_COOKIE) {
+            context->counters[DHCP_COUNTERS_CURRENT][dir][BOOTP_MESSAGE]++;
+            aggregate_dev.counters[DHCP_COUNTERS_CURRENT][dir][BOOTP_MESSAGE]++;
+            return;
+        }
         int offset = 0;
         while ((offset < (dhcp_option_sz + 1)) && dhcp_option[offset] != 255) {
             if (dhcp_option[offset] == OPTION_DHCP_MESSAGE_TYPE) {

--- a/src/dhcp_device.h
+++ b/src/dhcp_device.h
@@ -32,6 +32,7 @@ typedef enum
     DHCP_MESSAGE_TYPE_NAK      = 6,
     DHCP_MESSAGE_TYPE_RELEASE  = 7,
     DHCP_MESSAGE_TYPE_INFORM   = 8,
+    BOOTP_MESSAGE              = 9,
 
     DHCP_MESSAGE_TYPE_COUNT
 } dhcp_message_type_t;


### PR DESCRIPTION
### Why I did it
Manually cherry-pick of this PR: https://github.com/sonic-net/sonic-dhcpmon/pull/31
In previous, if switch receives bootp packets with vendor specific options rather than DHCP body, dhcpmon would treat them as DHCP packets and count them. Since the packets body is not DHCP format, it's not expected and would cause incorrect counting data generated image

### How I did it
Per RFC 2131, add check for DHCP magic cookie to make sure dhcpmon would only count DHCP packets

### How I verify it
Install new dhcpmon and send bootp packets manully and we can see bootp packets wouldn't be counted as DHCP packets Install new dhcpmon and run dhcp_relay related tests in sonic-mgmt, all passed