### PR TITLE
Update key in COUNTERS_DB

### DIFF
--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -303,7 +303,7 @@ void initialize_db_counters(std::string &ifname)
      */
     std::string table_name;
     if (downstream_if_name.compare(ifname) != 0) {
-        table_name = DB_COUNTER_TABLE + downstream_if_name + "_" + ifname;
+        table_name = DB_COUNTER_TABLE + downstream_if_name + "|" + ifname;
     } else {
         table_name = DB_COUNTER_TABLE + ifname;
     }

--- a/src/dhcp_mon.cpp
+++ b/src/dhcp_mon.cpp
@@ -167,7 +167,7 @@ void update_counter(dhcp_packet_direction_t dir) {
          * Only add downstream prefix for non-downstream interface
          */
         if (downstream_if_name.compare(interface_name) != 0) {
-            table_name = DB_COUNTER_TABLE + downstream_if_name + "_" + interface_name;
+            table_name = DB_COUNTER_TABLE + downstream_if_name + "|" + interface_name;
         } else {
             table_name = DB_COUNTER_TABLE + interface_name;
         }


### PR DESCRIPTION
### Why I did it
Align COUNTERS_DB schema with HLD for per-interface counter. HLD: https://github.com/sonic-net/SONiC/blob/master/doc/dhcp_relay/DHCPv4-per-interface-counter.md

### How I did it
Use vertical bar to construct keys instead of underscore

### How I verify it
Before:
```
admin@sonic:~$ sonic-db-cli COUNTERS_DB keys "DHCPV4_COUNTER_TABLE*"
DHCPV4_COUNTER_TABLE|Vlan1000_Ethernet44
DHCPV4_COUNTER_TABLE|Vlan1000_Ethernet39
DHCPV4_COUNTER_TABLE|Vlan1000_Ethernet27
DHCPV4_COUNTER_TABLE|Vlan1000
```
After:
```
admin@bjw-can-720dt-1:~$ sonic-db-cli COUNTERS_DB keys "DHCPV4_COUNTER_TABLE*"
DHCPV4_COUNTER_TABLE|Vlan1000|PortChannel101
DHCPV4_COUNTER_TABLE|Vlan1000|Ethernet10
DHCPV4_COUNTER_TABLE|Vlan1000|Ethernet16
DHCPV4_COUNTER_TABLE|Vlan1000|Ethernet2
DHCPV4_COUNTER_TABLE|Vlan1000
```
