### PR TITLE
Update DB separator for per-interface counter

### DIFF
--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -303,9 +303,9 @@ void initialize_db_counters(std::string &ifname)
      */
     std::string table_name;
     if (downstream_if_name.compare(ifname) != 0) {
-        table_name = DB_COUNTER_TABLE + downstream_if_name + "|" + ifname;
+        table_name = DB_COUNTER_TABLE_PREFIX + downstream_if_name + DB_SEPARATOR + ifname;
     } else {
-        table_name = DB_COUNTER_TABLE + ifname;
+        table_name = DB_COUNTER_TABLE_PREFIX + ifname;
     }
     auto init_value = generate_json_string(nullptr);
     mCountersDbPtr->hset(table_name, "RX", init_value);

--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -303,7 +303,7 @@ void initialize_db_counters(std::string &ifname)
      */
     std::string table_name;
     if (downstream_if_name.compare(ifname) != 0) {
-        table_name = DB_COUNTER_TABLE_PREFIX + downstream_if_name + DB_SEPARATOR + ifname;
+        table_name = DB_COUNTER_TABLE_PREFIX + downstream_if_name + COUNTERS_DB_SEPARATOR + ifname;
     } else {
         table_name = DB_COUNTER_TABLE_PREFIX + ifname;
     }

--- a/src/dhcp_device.h
+++ b/src/dhcp_device.h
@@ -19,8 +19,9 @@
 
 #include "subscriberstatetable.h"
 
-/* STATE_DB DHCP counter table name */
-#define DB_COUNTER_TABLE "DHCPV4_COUNTER_TABLE|"
+/* COUNTERS_DB DHCP counter table name */
+#define DB_COUNTER_TABLE_PREFIX "DHCPV4_COUNTER_TABLE:"
+#define DB_SEPARATOR ":"
 
 extern std::shared_ptr<swss::DBConnector> mCountersDbPtr;
 extern bool dual_tor_sock;

--- a/src/dhcp_device.h
+++ b/src/dhcp_device.h
@@ -21,7 +21,7 @@
 
 /* COUNTERS_DB DHCP counter table name */
 #define DB_COUNTER_TABLE_PREFIX "DHCPV4_COUNTER_TABLE:"
-#define DB_SEPARATOR ":"
+#define COUNTERS_DB_SEPARATOR ":"
 
 extern std::shared_ptr<swss::DBConnector> mCountersDbPtr;
 extern bool dual_tor_sock;

--- a/src/dhcp_mon.cpp
+++ b/src/dhcp_mon.cpp
@@ -167,9 +167,9 @@ void update_counter(dhcp_packet_direction_t dir) {
          * Only add downstream prefix for non-downstream interface
          */
         if (downstream_if_name.compare(interface_name) != 0) {
-            table_name = DB_COUNTER_TABLE + downstream_if_name + "|" + interface_name;
+            table_name = DB_COUNTER_TABLE_PREFIX + downstream_if_name + DB_SEPARATOR + interface_name;
         } else {
-            table_name = DB_COUNTER_TABLE + interface_name;
+            table_name = DB_COUNTER_TABLE_PREFIX + interface_name;
         }
         mCountersDbPtr->hset(table_name, (dir == DHCP_RX) ? "RX" : "TX", value);
     }

--- a/src/dhcp_mon.cpp
+++ b/src/dhcp_mon.cpp
@@ -167,7 +167,7 @@ void update_counter(dhcp_packet_direction_t dir) {
          * Only add downstream prefix for non-downstream interface
          */
         if (downstream_if_name.compare(interface_name) != 0) {
-            table_name = DB_COUNTER_TABLE_PREFIX + downstream_if_name + DB_SEPARATOR + interface_name;
+            table_name = DB_COUNTER_TABLE_PREFIX + downstream_if_name + COUNTERS_DB_SEPARATOR + interface_name;
         } else {
             table_name = DB_COUNTER_TABLE_PREFIX + interface_name;
         }


### PR DESCRIPTION
#### Why I did it
Per [database_config.json.j2](https://github.com/sonic-net/sonic-buildimage/blob/master/dockers/docker-database/database_config.json.j2), separator in COUNTERS_DB should be ":"

#### How I did it
Update separator to ":"

#### How to verify it
Manually test
```
admin@bjw-can-720dt-1:~$ sonic-db-cli COUNTERS_DB keys "DHCP*"
DHCPV4_COUNTER_TABLE:Vlan1000:PortChannel106
DHCPV4_COUNTER_TABLE:Vlan1000:Ethernet22
DHCPV4_COUNTER_TABLE:Vlan1000:Ethernet38
DHCPV4_COUNTER_TABLE:Vlan1000:Ethernet37
DHCPV4_COUNTER_TABLE:Vlan1000:Ethernet44
DHCPV4_COUNTER_TABLE:Vlan1000:Ethernet34
DHCPV4_COUNTER_TABLE:Vlan1000:Ethernet10
```