### PR TITLE
Add support for clear per-interface counter

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -41,7 +41,8 @@ jobs:
           libnl-route-3-dev \
           libnl-genl-3-dev \
           libnl-nf-3-dev \
-          libevent-dev
+          libevent-dev \
+          libjsoncpp-dev
     displayName: "Install dependencies"
   - checkout: self
     clean: true

--- a/objects.mk
+++ b/objects.mk
@@ -1,4 +1,4 @@
 USER_OBJS :=
 
-LIBS := -levent -lexplain -lswsscommon -pthread -lboost_thread -lboost_system -lhiredis -levent -levent_pthreads -lpthread
+LIBS := -levent -lexplain -lswsscommon -ljsoncpp -pthread -lboost_thread -lboost_system -lhiredis -levent -levent_pthreads -lpthread
 

--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -186,6 +186,9 @@ void update_vlan_mapping(std::shared_ptr<swss::DBConnector> db_conn) {
         auto first = itr.find_first_of('|');
         auto second = itr.find_last_of('|');
         auto vlan = itr.substr(first + 1, second - first - 1);
+        if (vlan.compare(downstream_if_name) != 0) {
+            continue;
+        }
         auto interface = itr.substr(second + 1);
         vlan_map[interface] = vlan;
         vlans.insert(vlan);

--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -326,7 +326,7 @@ void increase_cache_counter(std::string &ifname, uint8_t type, dhcp_packet_direc
     auto &counter_map = (dir == DHCP_RX) ? rx_counter : tx_counter;
     auto counter = counter_map.find(ifname);
     if (counter == counter_map.end()) {
-        syslog(LOG_WARNING, "Cannot find %s counter for %s\n", (dir == DHCP_RX ? "RX" : "TX"), ifname.c_str());
+        syslog(LOG_WARNING, "Cannot find %s counter for %s\n", gen_dir_str(dir, UPPER_CASE).c_str(), ifname.c_str());
         return;
     }
     counter->second[type]++;

--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -17,7 +17,6 @@
 #include <sys/ioctl.h>
 #include <arpa/inet.h>
 #include <unistd.h>
-#include <syslog.h>
 #include <inttypes.h>
 #include <libexplain/ioctl.h>
 #include <linux/filter.h>
@@ -76,7 +75,7 @@ std::unordered_map<std::string, std::string> mgmt_map;
 /* RX per-interface counter data */
 std::unordered_map<std::string, std::unordered_map<uint8_t, uint64_t>> rx_counter;
 
-/* RX per-interface counter data */
+/* TX per-interface counter data */
 std::unordered_map<std::string, std::unordered_map<uint8_t, uint64_t>> tx_counter;
 
 /* db counter name array, message type rage [1, 9] */
@@ -301,12 +300,7 @@ void initialize_db_counters(std::string &ifname)
     /**
      * Only add downstream prefix for non-downstream interface
      */
-    std::string table_name;
-    if (downstream_if_name.compare(ifname) != 0) {
-        table_name = DB_COUNTER_TABLE_PREFIX + downstream_if_name + COUNTERS_DB_SEPARATOR + ifname;
-    } else {
-        table_name = DB_COUNTER_TABLE_PREFIX + ifname;
-    }
+    std::string table_name = construct_counter_db_table_key(ifname);
     auto init_value = generate_json_string(nullptr);
     mCountersDbPtr->hset(table_name, "RX", init_value);
     mCountersDbPtr->hset(table_name, "TX", init_value);

--- a/src/dhcp_device.h
+++ b/src/dhcp_device.h
@@ -48,15 +48,6 @@ enum
     OPTION_DHCP_MESSAGE_TYPE = 53,
 };
 
-/** packet direction */
-typedef enum
-{
-    DHCP_RX,    /** RX DHCP packet */
-    DHCP_TX,    /** TX DHCP packet */
-
-    DHCP_DIR_COUNT
-} dhcp_packet_direction_t;
-
 /** counters type */
 typedef enum
 {

--- a/src/dhcp_device.h
+++ b/src/dhcp_device.h
@@ -18,16 +18,12 @@
 #include <event2/thread.h>
 
 #include "subscriberstatetable.h"
-
-/* COUNTERS_DB DHCP counter table name */
-#define DB_COUNTER_TABLE_PREFIX "DHCPV4_COUNTER_TABLE:"
-#define COUNTERS_DB_SEPARATOR ":"
+#include "util.h"
 
 extern std::shared_ptr<swss::DBConnector> mCountersDbPtr;
+extern std::shared_ptr<swss::DBConnector> mStateDbPtr;
 extern bool dual_tor_sock;
 extern std::unordered_map<std::string, struct intf*> intfs;
-/** Downstream interface name */
-extern std::string downstream_if_name;
 
 /**
  * DHCP message types

--- a/src/dhcp_mon.cpp
+++ b/src/dhcp_mon.cpp
@@ -494,8 +494,10 @@ int dhcp_mon_start(size_t snaplen, bool debug_mode)
     
         cache_db_diff = false;
         dhcp_packet_direction_t temp_dir_rx = DHCP_RX;
+        event_init_check_and_free(ev_rx_cache_counter_update);
         ev_rx_cache_counter_update = event_new(rx_event_mgr->get_base(), -1, 0, update_cache_counter, reinterpret_cast<void*>(&temp_dir_rx));
         dhcp_packet_direction_t temp_dir_tx = DHCP_TX;
+        event_init_check_and_free(ev_tx_cache_counter_update);
         ev_tx_cache_counter_update = event_new(tx_event_mgr->get_base(), -1, 0, update_cache_counter, reinterpret_cast<void*>(&temp_dir_tx));
 
         struct event *ev_timeout = event_new(main_event_mgr->get_base(), -1, EV_PERSIST, timeout_callback, main_event_mgr->get_base());
@@ -504,6 +506,7 @@ int dhcp_mon_start(size_t snaplen, bool debug_mode)
             break;
         }
 
+        event_init_check_and_free(ev_db_update);
         ev_db_update = event_new(main_event_mgr->get_base(), -1, EV_PERSIST, db_update_callback, main_event_mgr->get_base());
         if (ev_db_update == NULL) {
             syslog(LOG_ERR, "Could not create db update timer!\n");

--- a/src/dhcp_mon.cpp
+++ b/src/dhcp_mon.cpp
@@ -145,14 +145,22 @@ static void update_cache_counter(evutil_socket_t fd, short event, void *arg) {
     auto counter_map = dhcp_device_get_counter(dir);
     for (auto &itr : keys) {
         std::string interface;
+        std::string vlan;
         auto first = itr.find_first_of(":");
         auto last = itr.find_last_of(":");
         if (first == last) {
             // Vlan interfaces
             interface = itr.substr(first + 1, itr.length() - first);
+            vlan = itr.substr(first + 1, itr.length() - first);
         } else {
             // Physical interfaces
             interface = itr.substr(last + 1, itr.length() - last);
+            vlan = itr.substr(first + 1, last - first - 1);
+        }
+
+        if (vlan.compare(downstream_if_name) != 0) {
+            syslog(LOG_INFO, "Skip [%s - %s] since it's not related to current downstream interface\n", vlan.c_str(), interface.c_str());
+            continue;
         }
 
         auto interface_key = construct_counter_db_table_key(interface);

--- a/src/dhcp_mon.h
+++ b/src/dhcp_mon.h
@@ -8,6 +8,9 @@
 #ifndef DHCP_MON_H_
 #define DHCP_MON_H_
 
+#include <mutex>
+#include "util.h"
+
 /**
  * @code dhcp_mon_init(window_ssec, max_count, db_update_interval);
  *

--- a/src/subdir.mk
+++ b/src/subdir.mk
@@ -6,6 +6,7 @@ C_SRCS += \
 ../src/dhcp_device.cpp \
 ../src/dhcp_devman.cpp \
 ../src/dhcp_mon.cpp \
+../src/util.cpp \
 ../src/main.cpp 
 
 OBJS += \
@@ -13,6 +14,7 @@ OBJS += \
 ./src/dhcp_device.o \
 ./src/dhcp_devman.o \
 ./src/dhcp_mon.o \
+./src/util.o \
 ./src/main.o 
 
 C_DEPS += \
@@ -20,6 +22,7 @@ C_DEPS += \
 ./src/dhcp_device.d \
 ./src/dhcp_devman.d \
 ./src/dhcp_mon.d \
+./src/util.d \
 ./src/main.d 
 
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -61,3 +61,45 @@ bool parse_uint64_from_str(const std::string& str, uint64_t& result) {
         return false;
     }
 }
+
+/**
+ * @code  gen_dir_str(const dhcp_packet_direction_t& dir, const str_case_type case_type);
+ * @brief Function to generate dir string
+ * @param dir            direction, DHCP_RX or DHCP_TX
+ * @param case_type      UPPER_CASE or LOWER_CASE
+ * @return string of direction
+ */
+std::string gen_dir_str(const dhcp_packet_direction_t& dir, const str_case_type case_type) {
+    if (dir == DHCP_RX) {
+        if (case_type == UPPER_CASE)
+            return "RX";
+        else
+            return "rx";
+    } else {
+        if (case_type == UPPER_CASE)
+            return "TX";
+        else
+            return "tx";
+    }
+}
+
+/**
+ * @code void parse_counter_table_key(std::string& vlan, std::string& interface);
+ * @brief Function to parse key in counters_db
+ * @param key            key in counter table
+ * @param vlan           reference of parsed vlan string
+ * @param interface      reference of parsed interface string
+ */
+void parse_counter_table_key(std::string& key, std::string& vlan, std::string& interface) {
+    auto first = key.find_first_of(COUNTERS_DB_SEPARATOR);
+    auto last = key.find_last_of(COUNTERS_DB_SEPARATOR);
+    if (first == last) {
+        // Vlan interfaces
+        interface = key.substr(first + 1, key.length() - first);
+        vlan = key.substr(first + 1, key.length() - first);
+    } else {
+        // Physical interfaces
+        interface = key.substr(last + 1, key.length() - last);
+        vlan = key.substr(first + 1, last - first - 1);
+    }
+}

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -103,3 +103,18 @@ void parse_counter_table_key(std::string& key, std::string& vlan, std::string& i
         vlan = key.substr(first + 1, last - first - 1);
     }
 }
+
+/**
+ * @code void event_init_check_and_free(struct event *current_event);
+ * @brief Check whether event is NULL and re-init it
+ * @param current_event  point of event
+ */
+void event_init_check_and_free(struct event *current_event) {
+    if (current_event != NULL) {
+        if (event_pending(current_event, EV_READ | EV_WRITE | EV_TIMEOUT, nullptr)) {
+            event_del(current_event);
+        }
+
+        event_free(current_event);
+    }
+}

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,0 +1,63 @@
+#include "util.h"
+
+
+/**
+ * @code  construct_counter_db_table_key(const std::string &ifname);
+ * @brief Function to construct key in counters_db
+ * @param ifname       interface name
+ * @return string of counters_db key
+ */
+std::string construct_counter_db_table_key(const std::string &ifname) {
+    std::string key;
+    if (downstream_if_name.compare(ifname) != 0) {
+       key = COUNTERS_DB_COUNTER_TABLE_PREFIX + downstream_if_name + COUNTERS_DB_SEPARATOR + ifname;
+    } else {
+       key = COUNTERS_DB_COUNTER_TABLE_PREFIX + ifname;
+    }
+    return key;
+}
+
+/**
+ * @code  parse_json_str(const std::string *json_str, Json::Value* out_value);
+ * @brief Function to parse json string
+ * @param json_str       json string need to be parsed
+ * @param out_value      Json obj to store parsing result
+ * @return bool indicate parsing result
+ */
+bool parse_json_str(const std::string *json_str, Json::Value* out_value) {
+    if (!out_value) {
+        syslog(LOG_WARNING, "Pointer of out_value is NULL\n");
+        return false;
+    }
+
+    Json::CharReaderBuilder builder;
+    JSONCPP_STRING err;
+
+    const std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+    auto json_begin = json_str->c_str();
+    auto json_end = json_begin + json_str->length();
+    if (reader->parse(json_str->c_str(), json_end, out_value, &err)) {
+        return true;
+    } else {
+        syslog(LOG_WARNING, "Failed to parse json str: %s, %s\n", json_begin, err.c_str());
+        return false;
+    }
+}
+
+/**
+ * @code  parse_uint64_from_str(const std::string& str, uint64_t& result);
+ * @brief Function to parse uint64 from string
+ * @param str            string need to be parsed
+ * @param result         int referrence to store parsing result
+ * @return bool indicate parsing result
+ */
+bool parse_uint64_from_str(const std::string& str, uint64_t& result) {
+    try {
+        size_t idx = 0;
+        result = std::stoull(str, &idx);
+        return idx == str.size();
+    } catch (const std::exception& e) {
+        syslog(LOG_ALERT, "Failed to parse uint64_t from string '%s': %s", str.c_str(), e.what());
+        return false;
+    }
+}

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,38 @@
+#include <string>
+#include <memory>
+#include <jsoncpp/json/json.h>
+#include <syslog.h>
+#include <unordered_map>
+
+#define COUNTERS_DB_COUNTER_TABLE_PREFIX "DHCPV4_COUNTER_TABLE:"
+#define STATE_DB_COUNTER_UPDATE_PREFIX "DHCPV4_COUNTER_UPDATE|"
+#define COUNTERS_DB_SEPARATOR ":"
+
+extern std::string downstream_if_name;
+
+
+/**
+ * @code  construct_counter_db_table_key(const std::string &ifname);
+ * @brief Function to construct key in counters_db
+ * @param ifname       interface name
+ * @return string of counters_db key
+ */
+std::string construct_counter_db_table_key(const std::string &ifname);
+
+/**
+ * @code  parse_json_str(const std::string *json_str, Json::Value* out_value);
+ * @brief Function to parse json string
+ * @param json_str       json string need to be parsed
+ * @param out_value      Json obj to store parsing result
+ * @return bool indicate parsing result
+ */
+bool parse_json_str(const std::string *json_str, Json::Value* out_value);
+
+/**
+ * @code  parse_uint64_from_str(const std::string& str, uint64_t& result);
+ * @brief Function to parse uint64 from string
+ * @param str            string need to be parsed
+ * @param result         int referrence to store parsing result
+ * @return bool indicate parsing result
+ */
+bool parse_uint64_from_str(const std::string& str, uint64_t& result);

--- a/src/util.h
+++ b/src/util.h
@@ -1,3 +1,7 @@
+
+#ifndef UTIL_H
+#define UTIL_H
+
 #include <string>
 #include <memory>
 #include <jsoncpp/json/json.h>
@@ -10,6 +14,21 @@
 
 extern std::string downstream_if_name;
 
+/** packet direction */
+typedef enum
+{
+    DHCP_RX,    /** RX DHCP packet */
+    DHCP_TX,    /** TX DHCP packet */
+
+    DHCP_DIR_COUNT
+} dhcp_packet_direction_t;
+
+/** string case type */
+typedef enum
+{
+    UPPER_CASE,
+    LOWER_CASE
+} str_case_type;
 
 /**
  * @code  construct_counter_db_table_key(const std::string &ifname);
@@ -36,3 +55,23 @@ bool parse_json_str(const std::string *json_str, Json::Value* out_value);
  * @return bool indicate parsing result
  */
 bool parse_uint64_from_str(const std::string& str, uint64_t& result);
+
+/**
+ * @code  gen_dir_str(const dhcp_packet_direction_t& dir, const str_case_type case_type);
+ * @brief Function to generate dir string
+ * @param dir            direction, DHCP_RX or DHCP_TX
+ * @param case_type      UPPER_CASE or LOWER_CASE
+ * @return string of direction
+ */
+std::string gen_dir_str(const dhcp_packet_direction_t& dir, const str_case_type case_type);
+
+/**
+ * @code void parse_counter_table_key(std::string& vlan, std::string& interface);
+ * @brief Function to parse key in counters_db
+ * @param key            key in counter table
+ * @param vlan           reference of parsed vlan string
+ * @param interface      reference of parsed interface string
+ */
+void parse_counter_table_key(std::string& key, std::string& vlan, std::string& interface);
+
+#endif //UTIL_H

--- a/src/util.h
+++ b/src/util.h
@@ -7,6 +7,7 @@
 #include <jsoncpp/json/json.h>
 #include <syslog.h>
 #include <unordered_map>
+#include <event2/event.h>
 
 #define COUNTERS_DB_COUNTER_TABLE_PREFIX "DHCPV4_COUNTER_TABLE:"
 #define STATE_DB_COUNTER_UPDATE_PREFIX "DHCPV4_COUNTER_UPDATE|"
@@ -73,5 +74,12 @@ std::string gen_dir_str(const dhcp_packet_direction_t& dir, const str_case_type 
  * @param interface      reference of parsed interface string
  */
 void parse_counter_table_key(std::string& key, std::string& vlan, std::string& interface);
+
+/**
+ * @code void event_init_check_and_free(struct event *current_event);
+ * @brief Check whether event is NULL and re-init it
+ * @param current_event  point of event
+ */
+void event_init_check_and_free(struct event *current_event);
 
 #endif //UTIL_H


### PR DESCRIPTION
### Why I did it?
DB-based per-interface counter is added in previous, current PR is to add support for clear counter

### How I did it?
#### Overview
HLD: https://github.com/sonic-net/SONiC/pull/1861
When user invoke clear CLI, counter in DB would be cleared, then dhcpmon would read DB counter and sync it into cache counter.
Because dhcpmon would periodically write cache counter into DB, hence we need to stop writing to DB when clearing counter, below is the steps:
(The bold parts are added by current PR, the other parts would be added to CLI in another PR.
)
1. User invokes clear CLI. A lock would be required in case many users clear it at the same time.
2. CLI would send SIGUSR1 to corresponding dhcpmon processes.
3. **After dhcpmon receives SIGUSR1 signal, it would stop writing to COUNTERS_DB. And it would set `pause_write_to_db` in `STATE_DB[DHCPV4_COUNTER_UPDATE|Vlan100]]` to be `done`, then wait another signal (The max waiting time is 5s, if it doesn't receive it within 5s, it would recover writing to COUNTERS_DB)**
4. Once CLI detects writing to DB is stopped from STATE_DB, it would clear data in COUNTERS_DB and send SIGUSR2 to dhcpmon processes
5. **After dhcpmon receives SIGUSR2 signal, it would read counter data from COUNTERS_DB and sync it into cache. Once it's done, it would recover writing to COUNTERS_DB and set `tx_cache_update/rx_cache_update` in `STATE_DB[DHCPV4_COUNTER_UPDATE|Vlan100]]` to be `done**
6. After CLI detect cache update done from STATE_DB, it would release lock

#### Implement detail
1. Add callback function for SIGUSR1
1.1 Stop writing cache counter to COUNTERS_DB
1.2 Update STATE_DB to indicate stop done
2. Add callback function for SIGUSR2
2.1 Sync RX cache counter from COUNTERS_DB
2.2 Sync TX cache counter from COUNTERS_DB
2.3 Recover writing to COUNTERS_DB
2.4 Update STATE_DB
