### PR TITLE
Update clear_counter_timeout to fix clear counter issue

### DIFF
--- a/src/dhcp_mon.cpp
+++ b/src/dhcp_mon.cpp
@@ -52,6 +52,8 @@ static int db_update_interval_sec;
  *  in case recover signal is not sent by cli, add timeout here. After timeout, dhcpmon would update COUNTERS_DB as previous.
  */
 static int clear_counter_timeout = 5;
+static constexpr int MINIMAL_CLEAR_COUNTER_TIMEOUT_SEC = 5;
+static constexpr int CLEAR_COUNTER_DELAY_AFTER_DB_UPDATE_SEC = 1;
 /** Flag to determine whether to write cache counter to COUNTERS_DB.
  *  0b11 - write (rx and tx cache counter are both up to date)
  *  0b00 - don't write (Need to sync rx and tx cache counter from COUNTERS_DB)
@@ -376,11 +378,12 @@ int dhcp_mon_init(int window_sec, int max_count, int db_update_interval)
         db_update_interval_sec = db_update_interval;
 
         // Set clear_counter_timeout based on db_update_interval
-        if (db_update_interval < 4) {
-            clear_counter_timeout = 5;
+        if (db_update_interval < MINIMAL_CLEAR_COUNTER_TIMEOUT_SEC - CLEAR_COUNTER_DELAY_AFTER_DB_UPDATE_SEC) {
+            clear_counter_timeout = MINIMAL_CLEAR_COUNTER_TIMEOUT_SEC;
         } else {
-            clear_counter_timeout = db_update_interval + 1;
+            clear_counter_timeout = db_update_interval + CLEAR_COUNTER_DELAY_AFTER_DB_UPDATE_SEC ;
         }
+        syslog(LOG_INFO, "clear_counter_timeout is set to %is\n", clear_counter_timeout);
 
         if (main_event_mgr != NULL || rx_event_mgr != NULL || tx_event_mgr != NULL) {
             syslog(LOG_ERR, "Duplicated invoking of dhcp_mon_init, cannot determine whether mgr obj is expected\n");


### PR DESCRIPTION
### Why I did it
When we clear dhcp_relay ipv4 counter, cli would send a SIGUSR1 to stop writing DB, then sends a SIGUSR2 to sync DB to cache and continue timer to write DB.
If writing DB happens during SIGUSR1 and SIGUSR2, it would be ignored. But if the SIGUSR2 is not received after SIGUSR1 for a while (5s after last writing DB), it would timeout to break clear counter procedure.
There is such [fail to clear counter] with default startup parameter (Interval to write DB set to 20s):
1) 1st writing DB happened in 00:00:00.00
2) Clear CLI sent SIGUSR1 in 00:00:19.95
3) 2nd writing DB happened in 00:00:20.00 (Because there is already 20s since last update, which > 5s, it would interrupt clear procedure)
4) Clear CLI sent SIGUSR2 in 00:00:20.20 but it fails

### How I did it
If the db_update_interval < 5, then the clear timeout is set to 5, else, the clear timeout would be set to [db_update_interval + 1], it can make sure procedure of clearing counter wouldn't be interrupted by writing DB

### How I verify it
Manually test