### PR TITLE
[build] Update to install libyang3 in PR check

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -62,6 +62,7 @@ jobs:
       patterns: |
         target/debs/bookworm/libyang-*.deb
         target/debs/bookworm/libyang_*.deb
+        target/debs/bookworm/libyang3_*.deb
     displayName: "Download libyang from common lib"
   - script: |
       set -ex


### PR DESCRIPTION
dependency of libyang-dev changed, this PR is to add installing libyang3 in PR check
```
Setting up libyang (1.0.73) ...
Setting up libyang-dbgsym (1.0.73) ...
dpkg: dependency problems prevent configuration of libyang-dev:
 libyang-dev depends on libyang3 (= 3.12.2-1); however:
  Package libyang3 is not installed.
```