### PR TITLE
Add a dhcp type validation when increasing cache counter

### DIFF
--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -423,7 +423,7 @@ static void handle_dhcp_option_53(std::string &sock_if,
     uint8_t type = dhcp_option[2];
     if (type >= DHCP_MESSAGE_TYPE_COUNT) {
         syslog(LOG_WARNING, "Unexpected message type %d(0x%x)\n", type, type);
-        type = 0; // treate it as unknown counter
+        type = 0; // treat it as unknown counter
     }
     if (context_if.compare(sock_if) != 0) {
         // count for incomming physical interfaces

--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -319,6 +319,10 @@ void initialize_db_counters(std::string &ifname)
  */
 void increase_cache_counter(std::string &ifname, uint8_t type, dhcp_packet_direction_t dir)
 {
+    if (type >= DHCP_MESSAGE_TYPE_COUNT) {
+        syslog(LOG_WARNING, "Unexpected message type %d(0x%x)\n", type, type);
+        type = 0; // treat it as unknown counter
+    }
     auto &counter_map = (dir == DHCP_RX) ? rx_counter : tx_counter;
     auto counter = counter_map.find(ifname);
     if (counter == counter_map.end()) {


### PR DESCRIPTION
Why I did it:
DHCP monitor will crash when a packet with a undefined DHCP message type
How I did it:
Validate the DHCP type and convert it to 0 as unknown if it's undefined.
How I verify it
Send a dhcp packet with dhcp message type = 254