### PR TITLE
[init] Init physical interfaces without portchannel in counter

### DIFF
--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -293,12 +293,12 @@ std::string generate_json_string(const std::unordered_map<uint8_t, uint64_t>* co
 }
 
 /**
- * @code                void initialize_db_counters(std::string &ifname)
+ * @code                void initialize_db_counters(const std::string &ifname)
  * @brief               Initialize the counter in counters_db with interface name
  * @param ifname        interface name
  * @return              none
  */
-void initialize_db_counters(std::string &ifname)
+void initialize_db_counters(const std::string &ifname)
 {
     /**
      * Only add downstream prefix for non-downstream interface

--- a/src/dhcp_device.h
+++ b/src/dhcp_device.h
@@ -210,12 +210,12 @@ void dhcp_device_update_snapshot(dhcp_device_context_t *context);
 void dhcp_device_print_status(dhcp_device_context_t *context, dhcp_counters_type_t type);
 
 /**
- * @code                void initialize_db_counter(std::string &ifname)
+ * @code                void initialize_db_counter(const std::string &ifname)
  * @brief               Initialize the counter in counters_db with interface name
  * @param ifname        interface name
  * @return              none
  */
-void initialize_db_counters(std::string &ifname);
+void initialize_db_counters(const std::string &ifname);
 
 /**
  * @code initialize_cache_counter(std::unordered_map<std::string, std::unordered_map<uint8_t, uint64_t>> &counters, std::string interface_name);


### PR DESCRIPTION
### Why I did it?
Per-interface counter would only initialize db counter for mgmt port / vlan and vlan member port / portchannel and portchannel port. If the switch connects to  upstream with direct physical interfaces rather than portchannel, the uplink count would be missed

### How I did it?
Loop all upstream and downstream interfaces, init db counter for them

### How I test it?
1. Run dhcp_relay test
2. Manually test