### PR TITLE
[dhcp_mon] Add missing #include <algorithm> for std::replace

### DIFF
--- a/src/dhcp_mon.cpp
+++ b/src/dhcp_mon.cpp
@@ -11,6 +11,7 @@
 #include <sys/syscall.h>
 #include <assert.h>
 #include <chrono>
+#include <algorithm>
 
 #include "dhcp_mon.h"
 #include "dhcp_devman.h"


### PR DESCRIPTION
## Description
`std::replace` is used in `dhcp_mon.cpp` (line 171) but the required `<algorithm>` header was not included, causing compilation failures on some toolchains.

This patch adds the missing `#include <algorithm>`.

## Motivation
Fixes sonic-net/sonic-buildimage#23276

## Changes
- Added `#include <algorithm>` to `src/dhcp_mon.cpp`