### PR TITLE
 [dhcpmon] Add -std=c++17 compile flag for C++17 feature support

### DIFF
--- a/src/subdir.mk
+++ b/src/subdir.mk
@@ -42,6 +42,6 @@ C_DEPS += \
 src/%.o: src/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking: GCC C Compiler'
-	$(CC) -O3 -g3 -Wall -I/usr/include/swss -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -o "$@" "$<"
+	$(CC) -std=c++17 -O3 -g3 -Wall -I/usr/include/swss -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -o "$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '


### PR DESCRIPTION
 #### Why I did it
 The codebase uses C++17 structured bindings (`auto& [key, value]`) in
 multiple files (util.h, dhcp_devman.cpp, dhcp_mon.cpp, sock_mgr.cpp)
 but the Makefile did not specify `-std=c++17`. The buildimage environment
 (Debian Bullseye, g++ 10) defaults to C++14, causing compilation failures
 in the buildimage CI pipeline (#26524).
 
 #### How I did it
 Added `-std=c++17` to the compiler invocation in `src/subdir.mk`,
 consistent with other SONiC submodules (sonic-linkmgrd, sonic-dhcp-relay,
 sonic-eventd).
 
 #### How to verify it
 Build dhcpmon in the buildimage pipeline — compilation should succeed.