### PR TITLE
 [dhcpmon] Add -std=gnu++17 compile flag for C++17 and GNU extension support

### DIFF
--- a/src/subdir.mk
+++ b/src/subdir.mk
@@ -42,6 +42,6 @@ C_DEPS += \
 src/%.o: src/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking: GCC C Compiler'
-	$(CC) -O3 -g3 -Wall -I/usr/include/swss -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -o "$@" "$<"
+	$(CC) -std=gnu++17 -O3 -g3 -Wall -I/usr/include/swss -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -o "$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '


### PR DESCRIPTION
#### Why I did it
 The codebase uses C++17 structured bindings (`auto& [key, value]`) in
 multiple files (util.h, dhcp_devman.cpp, dhcp_mon.cpp, sock_mgr.cpp)
 but the Makefile did not specify a C++ standard flag. The buildimage
 environment (Debian Bullseye, g++ 10) defaults to gnu++14, causing
 compilation failures in the buildimage CI pipeline (#26524).
 
 #### How I did it
 Added `-std=gnu++17` to the compiler invocation in `src/subdir.mk`.
 Using `gnu++17` instead of strict `c++17` to also enable GNU extensions
 such as C99-style array designated initializers, which will allow
 replacing the current `unordered_map` check profile types with more
 efficient and const-correct plain arrays in a future PR.
 
 #### How to verify it
 Build dhcpmon in the buildimage pipeline — compilation should succeed.
