### PR TITLE
fix: migrate CI to Trixie and add missing #include <algorithm>

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -1,12 +1,12 @@
 parameters:
-- name: 'arch'
+- name: arch
   type: string
-- name: 'pool'
+- name: pool
   type: object
   default: {}
-- name: 'containerImage'
+- name: artifact_name
   type: string
-- name: 'codeCoverage'
+- name: codeCoverage
   type: boolean
   default: false
 
@@ -14,10 +14,11 @@ jobs:
 - job:
   displayName: ${{ parameters.arch }}
   timeoutInMinutes: 60
+
   pool: ${{ parameters.pool }}
 
   container:
-    image: ${{ parameters.containerImage }}
+    image: sonicdev-microsoft.azurecr.io:443/sonic-slave-trixie:$(BUILD_BRANCH)-${{ parameters.arch }}
 
   steps:
   - ${{ if and(eq(parameters.arch, 'amd64'), parameters.codeCoverage) }}:
@@ -32,7 +33,7 @@ jobs:
   - script: |
       sudo apt-get update
       sudo apt-get install -y \
-          libboost1.83-all-dev \
+          libboost-all-dev \
           libexplain-dev \
           libhiredis-dev \
           libnl-3-dev \
@@ -51,17 +52,18 @@ jobs:
       source: specific
       project: build
       pipeline: Azure.sonic-buildimage.common_libs
-      runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runVersion: 'specific'
+      pipelineId: '926659'
       path: $(Build.ArtifactStagingDirectory)/download
       ${{ if eq(parameters.arch, 'amd64') }}:
         artifact: common-lib
       ${{ else }}:
         artifact: common-lib.${{ parameters.arch }}
       patterns: |
-        target/debs/bookworm/libyang-*.deb
-        target/debs/bookworm/libyang_*.deb
-        target/debs/bookworm/libyang3_*.deb
+        target/debs/trixie/libyang-*.deb
+        target/debs/trixie/libyang_*.deb
+        target/debs/trixie/libyang3_*.deb
+        target/debs/trixie/libpcre*.deb
     displayName: "Download libyang from common lib"
   - script: |
       set -ex
@@ -74,15 +76,14 @@ jobs:
       project: build
       pipeline: Azure.sonic-swss-common
       ${{ if eq(parameters.arch, 'amd64') }}:
-        artifact: sonic-swss-common-bookworm
+        artifact: sonic-swss-common-trixie
       ${{ else }}:
-        artifact: sonic-swss-common-bookworm.${{ parameters.arch }}
+        artifact: sonic-swss-common-trixie.${{ parameters.arch }}
       runVersion: 'latestFromBranch'
-      runBranch: 'refs/heads/master'
+      runBranch: 'refs/heads/$(BUILD_BRANCH)'
       displayName: "Download sonic-swss-common"
   - script: |
       set -ex
-      # LIBSWSSCOMMON
       sudo dpkg -i libswsscommon_1.0.0_${{ parameters.arch }}.deb
       sudo dpkg -i libswsscommon-dev_1.0.0_${{ parameters.arch }}.deb
     workingDirectory: $(Pipeline.Workspace)/
@@ -93,7 +94,7 @@ jobs:
       cp ../*.deb $(Build.ArtifactStagingDirectory)
     displayName: "Compile sonic dhcpmon"
   - publish: $(Build.ArtifactStagingDirectory)
-    artifact: sonic-dhcpmon.${{ parameters.arch }}
+    artifact: ${{ parameters.artifact_name }}
     displayName: "Archive dhcpmon debian packages"
   - ${{ if and(eq(parameters.arch, 'amd64'), parameters.codeCoverage) }}:
     - task: PublishCodeCoverageResults@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,21 +8,27 @@ trigger:
     include:
       - "*"
 
+variables:
+  - name: BUILD_BRANCH
+    ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      value: $(System.PullRequest.TargetBranch)
+    ${{ else }}:
+      value: $(Build.SourceBranchName)
+
 jobs:
 - template: .azure-pipelines/build.yml
   parameters:
     arch: amd64
     pool:
       vmImage: 'ubuntu-24.04'
-    codeCoverage: false
-    containerImage: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:latest
+    artifact_name: sonic-dhcpmon.amd64
 - template: .azure-pipelines/build.yml
   parameters:
     arch: arm64
     pool: sonicso1ES-arm64
-    containerImage: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm-arm64:latest
+    artifact_name: sonic-dhcpmon.arm64
 - template: .azure-pipelines/build.yml
   parameters:
     arch: armhf
     pool: sonicso1ES-armhf
-    containerImage: sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm-armhf:latest
+    artifact_name: sonic-dhcpmon.armhf

--- a/src/subdir.mk
+++ b/src/subdir.mk
@@ -42,6 +42,6 @@ C_DEPS += \
 src/%.o: src/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking: GCC C Compiler'
-	$(CC) -std=c++17 -O3 -g3 -Wall -I/usr/include/swss -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -o "$@" "$<"
+	$(CC) -O3 -g3 -Wall -I/usr/include/swss -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@)" -o "$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '

--- a/src/util.h
+++ b/src/util.h
@@ -8,6 +8,7 @@
 #include <syslog.h>
 #include <unordered_map>
 #include <vector>
+#include <algorithm>
 #include <functional>
 #include <netinet/ip.h>
 #include <netinet/udp.h>


### PR DESCRIPTION
- Add #include <algorithm> to src/util.h for std::find/std::find_if (g++ 14 on Trixie requires explicit include, unlike g++ 12 on Bookworm)
- Remove redundant -std=c++17 flag (g++ 12+ defaults to gnu++17)
- Update CI container images from sonic-slave-bookworm to sonic-slave-trixie
- Update CI artifact references from bookworm to trixie

This aligns the dhcpmon CI with the sonic-buildimage build environment, which moved to Debian Trixie (g++ 14) starting from 202511.