### PR TITLE
[dhcpmon] Cleanup stale v6 counters from COUNTERS_DB

### DIFF
--- a/src/dhcp_mon.cpp
+++ b/src/dhcp_mon.cpp
@@ -181,18 +181,20 @@ static bool all_counters_initialized(const std::string &ifname)
 static void cleanup_stale_db_counters()
 {
     syslog_debug(LOG_INFO, "Cleaning up stale counters in counters_db");
-    std::string match_pattern = construct_counter_db_table_key(downstream_ifname, false) + COUNTERS_DB_SEPARATOR "*";
-    auto keys = mCountersDbPtr->keys(match_pattern);
-    for (const auto &key : keys) {
-        auto [vlan, ifname] = parse_counter_table_key(key);
-        if (vlan != downstream_ifname) {
-            continue;
+    for (bool is_v6 : {false, true}) {
+        std::string match_pattern = construct_counter_db_table_key(downstream_ifname, is_v6) + COUNTERS_DB_SEPARATOR "*";
+        auto keys = mCountersDbPtr->keys(match_pattern);
+        for (const auto &key : keys) {
+            auto [vlan, ifname] = parse_counter_table_key(key);
+            if (vlan != downstream_ifname) {
+                continue;
+            }
+            if (dhcp_devman_is_tracked_interface(ifname)) {
+                continue;
+            }
+            syslog_debug(LOG_INFO, "Deleting stale counter entry for interface %s", ifname.c_str());
+            mCountersDbPtr->del(key);
         }
-        if (dhcp_devman_is_tracked_interface(ifname)) {
-            continue;
-        }
-        syslog_debug(LOG_INFO, "Deleting stale counter entry for interface %s", ifname.c_str());
-        mCountersDbPtr->del(key);
     }
 }
 


### PR DESCRIPTION
### Why I did it

Follow-up to PR #62 (DHCPv6 support). `cleanup_stale_db_counters()` only scans `DHCPV4_COUNTER_TABLE:*` keys, so stale `DHCPV6_COUNTER_TABLE:*` entries (e.g. interfaces removed from a VLAN, or a VLAN that flipped between dhcpv4_relay and dhcpv6_relay configs) are never purged from COUNTERS_DB.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

### How I did it

Wrap the existing match/delete logic in `for (bool is_v6 : {false, true})` and pass `is_v6` to `construct_counter_db_table_key()`. Both call sites — startup (`initialize_all_intf_counters()`) and the periodic `db_update_callback()` — pick up the v6 path automatically.

### How to verify it

On a v6-relay testbed, remove an interface from a Vlan (or flip its relay config from v6 back to v4) and confirm that the corresponding `DHCPV6_COUNTER_TABLE:<vlan>:<ifname>` entry is removed from COUNTERS_DB after the next `db_update_callback()` tick.

### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Tested branch (Please provide the tested image version)

- [ ] master
