### PR TITLE
[dhcpmon] Log Relay-Forward / Relay-Reply counters in v6 status

### DIFF
--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -341,6 +341,16 @@ static void dhcp_print_counters_v6(const std::string &ifname, dhcp_counters_type
         DHCP_COUNTER_WIDTH, rx_counter.at(DHCPV6_MESSAGE_TYPE_REPLY),
         DHCP_COUNTER_WIDTH, tx_counter.at(DHCPV6_MESSAGE_TYPE_REPLY)
     );
+    syslog(
+        LOG_INFO,
+        "[%*s -%*s rx/tx] Relay-Forward: %*" PRIu64 "/%*" PRIu64
+        ", Relay-Reply: %*" PRIu64 "/%*" PRIu64,
+        IF_NAMESIZE, ifname.c_str(), 13, counter_desc[type],
+        DHCP_COUNTER_WIDTH, rx_counter.at(DHCPV6_MESSAGE_TYPE_RELAY_FORW),
+        DHCP_COUNTER_WIDTH, tx_counter.at(DHCPV6_MESSAGE_TYPE_RELAY_FORW),
+        DHCP_COUNTER_WIDTH, rx_counter.at(DHCPV6_MESSAGE_TYPE_RELAY_REPL),
+        DHCP_COUNTER_WIDTH, tx_counter.at(DHCPV6_MESSAGE_TYPE_RELAY_REPL)
+    );
 }
 
 void dhcp_device_print_status(const std::string &ifname, dhcp_counters_type_t type)


### PR DESCRIPTION
### Why I did it

Follow-up to PR #62 (DHCPv6 support). `dhcp_print_counters_v6()` only emits the four "endpoint" message types (Solicit, Advertise, Request, Reply). On a relay's upstream interface (e.g. a PortChannel) the only DHCPv6 traffic that ever flows is encapsulated as Relay-Forward (tx) and Relay-Reply (rx), so the per-interval status line for upstream interfaces always reports zeros and the operator has no visibility into the actual relay traffic.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

### How I did it

Add a second `syslog()` call alongside the existing one to print the `RELAY_FORW`/`RELAY_REPL` counters. The original line is left untouched (same column widths, same content) so any log tooling that already parses it is unaffected — the new relay counters appear on a fresh line beneath it.

### How to verify it

On a v6-relay testbed, drive Relay-Forward / Relay-Reply traffic through an upstream interface (e.g. PortChannel101) and confirm a second status line appears in syslog showing non-zero `Relay-Forward`/`Relay-Reply` rx/tx counters for that interface. Existing `Solicit/Advertise/Request/Reply` line for downstream Vlan interfaces is unchanged.

### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

### Tested branch (Please provide the tested image version)

- [ ] master
