### PR TITLE
[dhcp_devman] Ignore duplicate -i* arguments instead of crashing/leaking

### DIFF
--- a/src/dhcp_devman.cpp
+++ b/src/dhcp_devman.cpp
@@ -76,6 +76,20 @@ int dhcp_devman_add_intf(const char *name, char intf_type)
 {
     int rv = -1;
 
+    // Guard against duplicate -i* arguments referring to the same interface
+    // (e.g. an interface that appears twice on the dhcpmon command line because
+    // the supervisor template emitted it for two IP prefixes). Without this
+    // check, the per-type counter is incremented twice (which trips the
+    // `<= 1` asserts for -id/-im), and `intfs[name] = context;` below silently
+    // overwrites and leaks the previously-registered device context. Treat
+    // duplicates as a no-op success so the caller's error path does not fire.
+    if (intfs.find(name) != intfs.end()) {
+        syslog(LOG_INFO,
+               "Ignoring duplicate -i%c for interface %s (already registered)",
+               intf_type, name);
+        return 0;
+    }
+
     do {
         switch (intf_type) {
             case 'u':


### PR DESCRIPTION
**Defense in depth** for the duplicate-`-i*` case discussed in sonic-net/sonic-buildimage#27277.

`dhcp_devman_add_intf()` is called once per `-id`/`-iu`/`-im` flag from `main.cpp`. There is no check that the same interface name has not already been registered. If the supervisor template (`dhcp-relay.monitors.j2`) emits the same upstream interface twice — which happens today when an interface has two IP prefixes (e.g. a Vlan with secondary subnets, or a dual-stack PortChannel after the v4-or-v6 expansion) — the second call:

1. Increments the per-type counter again. For `-id`/`-im` that immediately trips `assert(dhcp_num_south_intf <= 1)` / `assert(dhcp_num_mgmt_intf <= 1)` and aborts. For `-iu` it just leaves the counter wrong.
2. Overwrites `intfs[name]` with a fresh `dhcp_device_context_t *`, leaking the earlier context (and its sockets) because nothing calls `dhcp_device_shutdown()` on it.

The supervisor template is being fixed (sonic-net/sonic-buildimage#27277), but dhcpmon should also be defensive: any future template regression or operator-supplied invocation that happens to repeat an `-i*` flag should fail closed.

This PR adds an early-return guard at the top of `dhcp_devman_add_intf()` that uses `intfs.find(name)` to detect an already-registered name. On a hit it logs INFO and returns 0 (so `main.cpp:142` does not exit). The check runs **before** any state mutation — counter, asserts, `downstream_ifname`/`mgmt_ifname` assignment, `dhcp_device_init`, and the `intfs[]` write.

### How to test
- With current dhcpmon: run `/usr/sbin/dhcpmon -id Vlan1000 -id Vlan1000` → asserts and aborts (or registers garbage in non-debug builds).
- With this PR: same command → first `-id Vlan1000` registers normally; second logs `Ignoring duplicate -id for interface Vlan1000 (already registered)` and returns 0; daemon proceeds.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
