### PR TITLE
azure-pipelines: migrate libyang1 deb install to libyang3

### DIFF
--- a/.azure-pipelines/build.yml
+++ b/.azure-pipelines/build.yml
@@ -60,9 +60,9 @@ jobs:
       ${{ else }}:
         artifact: common-lib.${{ parameters.arch }}
       patterns: |
-        target/debs/trixie/libyang-*.deb
-        target/debs/trixie/libyang_*.deb
         target/debs/trixie/libyang3_*.deb
+        target/debs/trixie/libyang-dev_3*.deb
+        target/debs/trixie/python3-libyang_*.deb
         target/debs/trixie/libpcre*.deb
     displayName: "Download libyang from common lib"
   - script: |


### PR DESCRIPTION
#### Why I did it

`sonic-buildimage` no longer builds the libyang1 debs (`libyang_1.0.73`, `libyang-cpp`, `python3-yang`); it now builds **only** libyang3. The CI download step here was still pulling the removed v1 debs from the `common_libs` build artifact, which will now fail to find them.

Part of sonic-net/sonic-buildimage#22385.

#### How I did it

Updated the `common-lib` artifact download filters in `.azure-pipelines/build.yml` to fetch the libyang3 debs, using versionless globs (no hardcoded versions):

- `libyang_*.deb` / `libyang-*.deb` (v1) -> `libyang3_*.deb` + `libyang-dev_*.deb`
- `python3-yang_*.deb` -> `python3-libyang_*.deb`
- `libyang-cpp_*.deb` -> removed (no longer produced)

The install step uses a generic `find ./download -name *.deb`, so it required no change.

#### How to verify it

CI build should download and `dpkg -i` the libyang3 debs from the `common_libs` pipeline artifact and build successfully.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes, not new features. If this PR is to backport a fix, please specify the release branch(es) here.
-->

#### Description for the changelog

azure-pipelines: migrate libyang1 deb install to libyang3
