### PR TITLE
[dhcp_device]: Tolerate multiple IPv6 link-local addresses on interface

### DIFF
--- a/src/dhcp_device.cpp
+++ b/src/dhcp_device.cpp
@@ -465,9 +465,11 @@ int initialize_intf_mac_and_ip_addr(dhcp_device_context_t *context)
             if (ifa->ifa_addr->sa_family == AF_INET6) {
                 struct sockaddr_in6 *ipv6 = (struct sockaddr_in6 *)ifa->ifa_addr;
                 if (IN6_IS_ADDR_LINKLOCAL(&ipv6->sin6_addr)) {
-                    context->ipv6_lla = ipv6->sin6_addr;
+                    if (num_ipv6_lla == 0) {
+                        context->ipv6_lla = ipv6->sin6_addr;
+                    }
                     syslog(LOG_INFO, "Interface %s has IPv6 LLA %s", context->intf,
-                           generate_addr_string((const uint8_t *)&context->ipv6_lla, sizeof(context->ipv6_lla)).c_str());
+                           generate_addr_string((const uint8_t *)&ipv6->sin6_addr, sizeof(ipv6->sin6_addr)).c_str());
                     num_ipv6_lla++;
                 } else if (addr6_is_primary(context->intf, &ipv6->sin6_addr)) {
                     context->ipv6_gua = ipv6->sin6_addr;
@@ -484,8 +486,8 @@ int initialize_intf_mac_and_ip_addr(dhcp_device_context_t *context)
         }
         freeifaddrs(ifaddr);
 
-        if (num_ip_addr != 1 || (num_ipv6_gua != 1 && num_ipv6_lla != 1)) {
-            syslog(LOG_ALERT, "Unable to find exactly 1 ip addr, 1 ipv6 GUA and 1 ipv6 LLA on physical interface "
+        if (num_ip_addr != 1 || (num_ipv6_gua < 1 && num_ipv6_lla < 1)) {
+            syslog(LOG_ALERT, "Unable to find ip addr and at least 1 ipv6 GUA or LLA on physical interface "
                    "and 1 ipv6 loopback addr on loopback interface: %s", context->intf);
             break;
         }


### PR DESCRIPTION
#### Why I did it

Fix https://github.com/sonic-net/sonic-buildimage/issues/27586

After sonic-net/sonic-dhcpmon#62, dhcpmon exits during startup when the management interface has more than one IPv6 link-local address. This is a valid Linux networking configuration (e.g., both a kernel EUI-64 LLA and a statically configured management LLA coexist on eth0). The strict equality check causes dhcpmon to treat this as fatal, breaking DHCP relay health monitoring and blocking sonic-mgmt dhcpv4 relay tests.

#### How I did it
* Relaxed the validation condition from requiring exactly 1 LLA to requiring at least 1 LLA (or GUA)
* Stored only the first discovered LLA for packet identification, logging all subsequent LLAs

#### How to verify it
1. Add a second IPv6 link-local address to eth0: `ip -6 addr add fe80::dead:beef:1/64 dev eth0 scope link`
2. Restart the dhcp_relay container and verify dhcpmon starts successfully: `docker exec dhcp_relay supervisorctl status dhcpmon-Vlan1000`
3. Confirm the first LLA is used for relay identification in syslog

#### Description for the changelog
Fixed dhcpmon crash on interfaces with multiple IPv6 link-local addresses by tolerating any number of LLAs and using the first one found.