### PR TITLE
Fix tx_first_relay_reply src_ip check for dualtor topology

### DIFF
--- a/src/dhcp_check_profile_relay.cpp
+++ b/src/dhcp_check_profile_relay.cpp
@@ -67,7 +67,7 @@ dhcp_check_profile_t dhcp_check_profile_first_relay_rx = {
 // downlink interfaces, the src ip can be used to filter out which interface the packet is sent from.
 static dhcp_msg_check_profile_t tx_first_relay_reply = {
     {DHCP_CHECK_INTF_TYPE, (const void *)(new std::vector<dhcp_device_intf_t>{DHCP_DEVICE_INTF_TYPE_DOWNLINK, DHCP_DEVICE_INTF_TYPE_MGMT})},
-    {DHCP_CHECK_SRC_IP, (const void *)(new std::vector<const in_addr *>{&giaddr_ip})},
+    {DHCP_CHECK_SRC_IP, (const void *)(new std::vector<const in_addr *>{&vlan_ip})},
     {DHCP_CHECK_DST_IP, (const void *)(new std::vector<const in_addr *>{&broadcast_ip})},
     {DHCP_CHECK_GIADDR, (const void *)(new std::vector<const in_addr *>{&giaddr_ip})},
 };


### PR DESCRIPTION
Description of the bug
The tx_first_relay_reply check profile in src/dhcp_check_profile_relay.cpp includes a DHCP_CHECK_SRC_IP condition that requires src_ip == giaddr_ip. In dualtor mode, giaddr_ip is set to the Loopback0 IP (e.g. 10.1.0.32) per dhcp_devman.cpp:262. However, both ISC relay and dhcp4relay correctly use the Vlan SVI (e.g. 192.168.0.1) as the L3 source of outbound DHCP replies. These are semantically independent fields: giaddr identifies the relay for routing; src_ip is the packet's L3 source for client-side ARP and routing.

Because src_ip != giaddr_ip on every outbound Offer/Ack/Nak in dualtor, the profile check fails and packet_handler.cpp increments IGNORED instead of the actual message type. This was introduced by commit 57036c7 (PR https://github.com/sonic-net/sonic-mgmt/pull/62, "Add DHCPv6 monitoring support") and does not affect branch 202511.
Fixes : https://github.com/sonic-net/sonic-mgmt/issues/25393

### Type of change

<!--
- Fill x for your type of change.
- e.g.
- [x] Bug fix
-->

- [x] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
    - [ ] Skipped for non-supported platforms
- [ ] Test case improvement


### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- 
**Approach**

Set up a dualtor testbed running a build that includes PR https://github.com/sonic-net/sonic-mgmt/pull/62 (master).

Generate DHCP traffic through either ISC relay or dhcp4relay on a Vlan interface.

Check dhcpmon counters:

sonic-db-cli COUNTERS_DB hgetall "DHCPV4_COUNTER_TABLE:Vlan1000"

Observe TX:Offer = 0 despite relays forwarding correctly.

Actual Behavior and Expected Behavior
Current behaviour
Test failure:
WARNING | Warning for comparing Vlan1000 counters and Vlan1000 from pkts counters, hostname:ld209.
DHCP counter TX Offer: actual value 0, expected value 2754, the actual value is not equal to the expected value
Raw Redis counter from DHCPV4_COUNTER_TABLE:Vlan1000 (written by dhcpmon, read by the test and CLI):

RX: {'Discover':'2781','Offer':'0','Request':'0','Ack':'0','Nak':'0','Ignored':'0',...}
TX: {'Discover':'0', 'Offer':'0', 'Request':'0','Ack':'0','Nak':'0','Ignored':'2785',...}
Every outbound Offer is mis-classified as Ignored. show dhcp_relay ipv4 counters shows no Offers/Acks.

Expected behaviour:
Outbound DHCP replies are classified by message type. TX:Offer = N matches the number of forwarded Offers. TX:Ignored is 0 for normal traffic.
#### How did you do it?
Set up a dualtor testbed running a build that includes PR https://github.com/sonic-net/sonic-mgmt/pull/62 (master).

Generate DHCP traffic through either ISC relay or dhcp4relay on a Vlan interface.

Check dhcpmon counters:

sonic-db-cli COUNTERS_DB hgetall "DHCPV4_COUNTER_TABLE:Vlan1000"

Observe TX:Offer = 0 despite relays forwarding correctly.

Fix: 
change giaddr_ip to vlan_ip for DHCP_CHECK_SRC_IP

#### How did you verify it?
Ran the test_dhcp_counter_stress test on both dtAA and t0 topologies and the test passed
validated the counters
#### Any platform specific information?
NA

#### Supported testbed topology if it's a new test case?
NA 
### Documentation
<!--
(If it's a new feature, new test case)
Did you update documentation/Wiki relevant to your implementation?
Link to the wiki page?
-->
